### PR TITLE
Remove deepcopy from __rmul__ and __mul__ in MPS and MPO

### DIFF
--- a/seemps/operators/mpo.py
+++ b/seemps/operators/mpo.py
@@ -60,6 +60,10 @@ class MPO(array.TensorArray):
         assert data[0].shape[0] == data[-1].shape[-1] == 1
         self.strategy = strategy
 
+    def copy(self):
+        """Return a copy of the MPO."""
+        return copy.copy(self)
+
     def __add__(self, A: Union[MPO, MPOList, MPOSum]) -> MPOSum:
         """Represent `self + A` as :class:`.MPOSum`."""
         if isinstance(A, (MPO, MPOList)):
@@ -80,7 +84,7 @@ class MPO(array.TensorArray):
     def __mul__(self, n: Weight) -> MPO:
         """Multiply an MPO by a scalar `n * self`"""
         if isinstance(n, (int, float, complex)):
-            mpo_mult = copy.deepcopy(self)
+            mpo_mult = self.copy()
             mpo_mult._data[0] = n * mpo_mult._data[0]
             return mpo_mult
         raise InvalidOperation("*", self, n)
@@ -88,7 +92,7 @@ class MPO(array.TensorArray):
     def __rmul__(self, n: Weight) -> MPO:
         """Multiply an MPO by a scalar `self * self`"""
         if isinstance(n, (int, float, complex)):
-            mpo_mult = copy.deepcopy(self)
+            mpo_mult = self.copy()
             mpo_mult._data[0] = n * mpo_mult._data[0]
             return mpo_mult
         raise InvalidOperation("*", n, self)

--- a/seemps/state/mps.py
+++ b/seemps/state/mps.py
@@ -146,6 +146,10 @@ class MPS(array.TensorArray):
         """
         return cls.from_vector(state.reshape(-1), state.shape, strategy, normalize)
 
+    def copy(self):
+        """Return a copy of the MPS."""
+        return copy.copy(self)
+
     def __add__(self, state: Union[MPS, MPSSum]) -> MPSSum:
         """Represent `self + state` as :class:`.MPSSum`."""
         if isinstance(state, MPS):
@@ -168,7 +172,7 @@ class MPS(array.TensorArray):
     def __mul__(self, n: Weight) -> MPS:
         """Compute `n * self` where `n` is a scalar."""
         if isinstance(n, (int, float, complex)):
-            mps_mult = copy.deepcopy(self)
+            mps_mult = self.copy()
             mps_mult._data[0] = n * mps_mult._data[0]
             mps_mult._error = np.abs(n) ** 2 * mps_mult._error
             return mps_mult
@@ -179,7 +183,7 @@ class MPS(array.TensorArray):
     def __rmul__(self, n: Weight) -> MPS:
         """Compute `self * n`, where `n` is a scalar."""
         if isinstance(n, (int, float, complex)):
-            mps_mult = copy.deepcopy(self)
+            mps_mult = self.copy()
             mps_mult._data[0] = n * mps_mult._data[0]
             mps_mult._error = np.abs(n) ** 2 * mps_mult._error
             return mps_mult

--- a/seemps/truncate/simplify.py
+++ b/seemps/truncate/simplify.py
@@ -146,13 +146,14 @@ def crappy_guess_combine_state(weights: list[Weight], states: list[MPS]) -> MPS:
             # Extend with zeros to accommodate new contribution
             newA = np.zeros((max(DL, a), d, max(DR, b)), dtype=sumA.dtype)
             newA[:DL, :, :DR] = sumA
-            sumA = newA
+        else:
+            newA = sumA.copy()
         dt = type(A[0, 0, 0] + sumA[0, 0, 0])
         if sumA.dtype != dt:
-            sumA = sumA.astype(dt)
+            newA = sumA.astype(dt)
         else:
-            sumA[:a, :, :b] += A
-        return sumA
+            newA[:a, :, :b] += A
+        return newA
 
     guess: MPS = weights[0] * states[0]
     for n, state in enumerate(states[1:]):

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -1,8 +1,9 @@
 import numpy as np
 from seemps.state import MPS, MPSSum
 from seemps.state.array import TensorArray
-from .tools import *
+
 from .fixture_mps_states import MPSStatesFixture
+from .tools import *
 
 
 class TestTensorArray(MPSStatesFixture):
@@ -129,7 +130,7 @@ class TestMPSOperations(MPSStatesFixture):
         A = MPS(self.inhomogeneous_state)
         B = 3.0 * A
         self.assertTrue(B is not A)
-        self.assertTrue(contain_different_objects(B, A))
+        self.assertTrue(contain_different_objects(B[0], A[0]))
 
     def test_multiplying_mps_by_non_scalar_raises_exception(self):
         A = MPS(self.inhomogeneous_state)


### PR DESCRIPTION
@juanjosegarciaripoll 

- Modification of the test of multiplying an MPS by a scalar, as before it was asserted that the resulting and original MPS should be different element by element, while it is only the first tensor that is modified.
- Change in crappy guess to perform a shallow copy of the tensors for the combination (it was not necessary before due to the deepcopy in __rmul__ and __mul__.