### PR TITLE
Simplify cross algorithm.

### DIFF
--- a/seemps/analysis/__init__.py
+++ b/seemps/analysis/__init__.py
@@ -1,3 +1,5 @@
 from .chebyshev import *
-from .mesh import *
 from .factories import *
+from .mesh import *
+from .sampling import *
+from .cross import *

--- a/seemps/analysis/cross.py
+++ b/seemps/analysis/cross.py
@@ -1,0 +1,492 @@
+from copy import deepcopy
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+from scipy.linalg import lu, solve_triangular  # type: ignore
+
+from ..state import MPS, Strategy
+from ..tools import DEBUG, log
+from ..truncate import SIMPLIFICATION_STRATEGY, simplify
+from ..typing import *
+from .integrals import integrate_mps
+from .mesh import Mesh
+from .sampling import random_mps_indices, sample_mps
+
+
+def maxvol_square(matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Returns the optimal row indices and matrix of coefficients for the square maxvol decomposition of a given matrix.
+    This algorithm finds a submatrix of a 'tall' matrix with maximal volume (determinant of the square submatrix).
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        A 'tall' matrix (more rows than columns) for which the square maxvol decomposition is to be computed.
+
+    Returns
+    -------
+    I : np.ndarray
+        The optimal row indices of the tall matrix. These indices correspond to rows that form a square submatrix
+        with maximal volume.
+    B : np.ndarray
+        The matrix of coefficients. This matrix represents the coefficients for the linear combination of rows in the
+        original matrix that approximates the remaining rows, namely, a matrix B such that A ≈ B A[I, :].
+    """
+    square_maxiter = 100
+    square_tol = 1.05
+    n, r = matrix.shape
+    if n <= r:
+        raise ValueError('Input matrix should be "tall"')
+    P, L, U = lu(matrix, check_finite=False)
+    I = P[:, :r].argmax(axis=0)
+    Q = solve_triangular(U, matrix.T, trans=1, check_finite=False)
+    B = solve_triangular(
+        L[:r, :], Q, trans=1, check_finite=False, unit_diagonal=True, lower=True
+    ).T
+    for _ in range(square_maxiter):
+        i, j = np.divmod(np.abs(B).argmax(), r)
+        if np.abs(B[i, j]) <= square_tol:
+            break
+        I[j] = i
+        bj = B[:, j]
+        bi = B[i, :].copy()
+        bi[j] -= 1.0
+        B -= np.outer(bj, bi / B[i, j])
+    return I, B
+
+
+def maxvol_rectangular(
+    matrix: np.ndarray, min_rank_change: int, max_rank_change: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Returns the optimal row indices and matrix of coefficients for the maxvol algorithm applied to a tall matrix.
+    This algorithm extends the square maxvol algorithm to find a 'rectangular' submatrix with more rows than the columns
+    of the original matrix.
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        A 'tall' matrix (more rows than columns) for which the rectangular maxvol decomposition is to be computed.
+    min_rank_change : int
+        The minimum number of rows to be added to the rank of the square submatrix.
+    max_rank_change : int
+        The maximum number of rows to be added to the rank of the square submatrix.
+
+    Returns
+    -------
+    I : np.ndarray
+        The optimal row indices of the tall matrix. These indices correspond to rows that form a rectangular
+        submatrix with more rows than the columns of the original matrix.
+    B : np.ndarray
+        The matrix of coefficients. This matrix represents the coefficients of the linear combination of rows
+        in the original matrix that approximates the remaining rows, namely, a matrix B such that A ≈ B A[I, :].
+    """
+    rectangular_tol = 1.10
+    n, r = matrix.shape
+    r_min = r + min_rank_change
+    r_max = r + max_rank_change if max_rank_change is not None else n
+    r_max = min(r_max, n)
+    if r_min < r or r_min > r_max or r_max > n:
+        raise ValueError("Invalid minimum/maximum number of added rows")
+    I0, B = maxvol_square(matrix)
+    I = np.hstack([I0, np.zeros(r_max - r, dtype=I0.dtype)])
+    S = np.ones(n, dtype=int)
+    S[I0] = 0
+    F = S * np.linalg.norm(B, axis=1) ** 2
+    for k in range(r, r_max):
+        i = np.argmax(F)
+        if k >= r_min and F[i] <= rectangular_tol**2:
+            break
+        I[k] = i
+        S[i] = 0
+        v = B.dot(B[i])
+        l = 1.0 / (1 + v[i])
+        B = np.hstack([B - l * np.outer(v, B[i]), l * v.reshape(-1, 1)])
+        F = S * (F - l * v * v)
+    I = I[: B.shape[1]]
+    B[I] = np.eye(B.shape[1], dtype=B.dtype)
+    return I, B
+
+
+def maxvol(matrix: np.ndarray, rank_change: int) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Chooses and applies the appropriate maxvol algorithm (square or rectangular) to find a submatrix
+    with maximal volume, and returns the indices of these rows along with the matrix of coefficients.
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        The input matrix on which the maxvol algorithm is to be applied.
+    rank_change : int
+        The desired change in rank for the matrix, determining whether to use the square or rectangular
+        maxvol algorithm.
+
+    Returns
+    -------
+    indices : np.ndarray
+        An array of indices corresponding to the rows that form a submatrix with maximal volume.
+    coefficients : np.ndarray
+        A matrix of coefficients such that A ≈ B A[I, :].
+    """
+
+    n, r = matrix.shape
+    max_rank_change = min(rank_change, n - r)
+    min_rank_change = min(rank_change, max_rank_change)
+    if n <= r:
+        indices = np.arange(n, dtype=int)
+        coefficients = np.eye(n)
+    elif max_rank_change == 0:
+        indices, coefficients = maxvol_square(matrix)
+    else:
+        indices, coefficients = maxvol_rectangular(
+            matrix, min_rank_change, max_rank_change
+        )
+
+    return indices, coefficients
+
+
+def random_initial_indices(
+    I_s: np.ndarray,
+    starting_bond: int,
+    rng: Optional[np.random.Generator] = None,
+) -> List[np.ndarray]:
+    """
+    Generates a list of random initial indices for tensor decomposition using a specified random number generator.
+    Each set of indices is chosen randomly from a given array of indices and progressively concatenated.
+
+    Parameters
+    ----------
+    I_s : np.ndarray
+        An array of possible indices from which the random indices are to be selected (physical indices).
+    starting_bond : int
+        The number of indices to be chosen randomly at each step.
+    rng : Optional[np.random.Generator], default=None
+        The random number generator to be used. If None, a default generator with a fixed seed is used.
+
+    Returns
+    -------
+    I_g : List[np.ndarray]
+        A list of arrays, each containing a set of randomly chosen indices. The size of each array grows progressively
+        as indices are concatenated at each step.
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    I_g = [np.array([], dtype=int)]
+    for i, i_s in reversed(list(enumerate(I_s))):
+        choice = rng.choice(i_s, size=starting_bond, replace=True).reshape(-1, 1)
+        if i == len(I_s) - 1:
+            I_g.insert(0, choice)
+        else:
+            I_g.insert(0, np.hstack([choice, I_g[0]]))
+    return I_g
+
+
+def sample_initial_indices(state: MPS) -> List[np.ndarray]:
+    """
+    Samples initial indices from a given MPS by performing a sweep of the cross interpolation algorithm.
+    This allows to give an arbitrary starting bond dimension and a hopefully better starting point leading
+    to faster convergence.
+
+    Parameters
+    ----------
+    state : MPS
+        The MPS from which the initial indices are to be sampled.
+
+    Returns
+    -------
+    I_g : List[np.ndarray]
+        A list of arrays containing the sampled indices.
+    """
+    rank_change = 0
+    sites = len(state)
+    I_s = [np.array([[0], [1]]) for _ in range(sites)]
+    I_le = [np.array([], dtype=int)] * (sites + 1)
+    I_g = [np.array([], dtype=int)] * (sites + 1)
+    _ones = lambda x: np.ones((x, 1), dtype=int)
+
+    # Forward pass
+    R = np.ones((1, 1))
+    for k in range(sites):
+        fiber = np.tensordot(R, state[k], 1)
+        r_le, s, r_g = fiber.shape
+        fiber_matrix = fiber.reshape(r_le * s, r_g)
+        Q, R = np.linalg.qr(fiber_matrix)
+        maxvol_rows, _ = maxvol(Q, rank_change)
+        R = Q[maxvol_rows, :] @ R
+        I_fiber_rows = np.hstack(
+            (np.kron(_ones(s), I_le[k]), np.kron(I_s[k], _ones(r_le)))
+        )
+        I_le[k + 1] = I_fiber_rows[maxvol_rows, :]
+
+    # Backward pass
+    R = np.ones((1, 1))
+    for k in reversed(range(sites)):
+        fiber = np.tensordot(state[k], R, 1)
+        r_le, s, r_g = fiber.shape
+        fiber_matrix = fiber.reshape(r_le, s * r_g)
+        Q, R = np.linalg.qr(fiber_matrix.T)
+        maxvol_rows, _ = maxvol(Q, rank_change)
+        R = (Q[maxvol_rows, :] @ R).T
+        I_fiber_cols = np.hstack(
+            (np.kron(_ones(r_g), I_s[k]), np.kron(I_g[k + 1], _ones(s)))
+        )
+        I_g[k] = I_fiber_cols[maxvol_rows, :]
+
+    return I_g
+
+
+def sample_tensor_fiber(
+    func: Callable,
+    mesh: Mesh,
+    mps_ordering: str,
+    i_le: np.ndarray,
+    i_s: np.ndarray,
+    i_g: np.ndarray,
+) -> np.ndarray:
+    """
+    Samples the k-th tensor fiber of the underlying MPS representation of a function from a collection of multi-indices
+    centered at a given site k. I.e, samples $A\left(J_{\le k-1}, i_k, J_{\g k}\right)$ (see dolgov2020 pag.7).
+
+    Parameters
+    ----------
+    func : Callable
+        The vector function to be evaluated.
+    mesh : Mesh
+        The mesh of points where the function is defined.
+    mps_ordering : str
+        The ordering of the MPS sites, determining with which transformation matrix the tensor fiber is sampled.
+    i_le : np.ndarray
+        The multi-indices coming from all sites smaller or equal to k ($J_{\le k-1}$) in the MPS.
+    i_s : np.ndarray
+        The physical indices, representing the physical dimension at site k of the underlying MPS.
+    i_g : np.ndarray
+        The multi-indices coming from all sites greater than k ($J_{\g k}$) in the MPS.
+
+    Returns
+    -------
+    fiber : np.ndarray
+        The sampled tensor fiber.
+    """
+    _ones = lambda x: np.ones((x, 1), dtype=int)
+    r_le = i_le.shape[0] if i_le.size > 0 else 1
+    r_g = i_g.shape[0] if i_g.size > 0 else 1
+    s = i_s.shape[0]
+    # Extend the i_s to allow the left and right multi-indices to get attached.
+    mps_indices = np.kron(np.kron(_ones(r_g), i_s), _ones(r_le))
+    # Attach the multi-indices to the left and right of the extended i_s.
+    if i_le.size > 0:
+        mps_indices = np.hstack((np.kron(_ones(s * r_g), i_le), mps_indices))
+    if i_g.size > 0:
+        mps_indices = np.hstack((mps_indices, np.kron(i_g, _ones(r_le * s))))
+    # Evaluate the function at the fiber indices
+    T = mesh.binary_transformation_matrix(mps_ordering)
+    fiber = func(mesh[mps_indices @ T]).reshape((r_le, s, r_g), order="F")
+    return fiber
+
+
+@dataclass
+class CrossResults:
+    state: MPS
+    converged: bool
+    message: str
+    errors: VectorLike
+    bonds: VectorLike
+    evaluations: VectorLike
+    times: VectorLike
+
+
+def cross_interpolation(
+    func: Callable,
+    mesh: Mesh,
+    starting_indices: Optional[List[np.ndarray]] = None,
+    bond_change: int = 1,
+    maxbond: int = 100,
+    maxiter: int = 100,
+    tol: float = 1e-10,
+    error_type: str = "sampling",
+    mps_ordering: str = "A",
+    strategy: Strategy = SIMPLIFICATION_STRATEGY.replace(normalize=False),
+    callback: Optional[Callable] = None,
+) -> CrossResults:
+    """
+    Performs cross interpolation on a vectorized function discretized on a mesh to obtain its
+    MPS representation using the maxvol algorithm on an Alternating Least Squares (ALS) scheme.
+
+    Parameters
+    ----------
+    func : Callable
+        The vectorized function to be approximated as a MPS.
+    mesh : Mesh
+        The mesh of points where the function is defined.
+    starting_indices : Optional[List[np.ndarray]], default=None
+        The initial indices I_g for the algorithm. If None, random indices with bond dimension 1 are used.
+    bond_change : int, default=1
+        The increment in the bond dimension at each sweep until reaching maxbond.
+    maxbond : int, default=100
+        The maximum bond dimension allowed for the MPS.
+    maxiter : int, default=100
+        The maximum number of sweeps allowed.
+    tol : float, default=1e-10
+        The error tolerance for convergence.
+    mps_ordering : str, default="A"
+        Determines the order of the sites in the MPS by changing how the function is sampled.
+    strategy : Strategy, default=Strategy()
+        The MPS simplification strategy to perform at the end of the algorithm.
+    callback : Optional[Callable], default=None
+        An optional callback function called on the state after each sweep.
+
+    Returns
+    -------
+    CrossResults
+        The results of the cross interpolation process, including the final MPS state, convergence status,
+        message, error, bond, time and evaluation count trajectories.
+    """
+
+    def get_error(state: MPS):
+        if error_type == "sampling":
+            mps_indices = random_mps_indices(state)
+            T = mesh.binary_transformation_matrix(mps_ordering)
+            mesh_samples = func(mesh[mps_indices @ T])
+            mps_samples = sample_mps(state, mps_indices)
+            error = np.max(np.abs(mps_samples - mesh_samples))
+        elif error_type == "norm":
+            if sweep == 0:
+                # Save a deepcopy (needs to copy the previous tensors) to a function attribute
+                get_error.state_prev = deepcopy(state)
+                return np.Inf
+            # TODO: Rethink about this way of checking convergence.
+            # Right now it is computing the relative change in norm.
+            # At the moment, this method is much more expensive than sampling.
+            strategy = Strategy(normalize=False)
+            error = abs(
+                simplify(state - get_error.state_prev, strategy=strategy).norm()
+                / get_error.state_prev.norm()
+            )
+            get_error.state_prev = deepcopy(state)
+        elif error_type == "integral":
+            if sweep == 0:
+                get_error.integral_prev = integrate_mps(
+                    state, mesh, integral_type="trapezoidal"
+                )
+                return np.Inf
+            # TODO: Implement Féjer quadrature (valid for arbitrary sites and exponentially convergent)
+            integral = integrate_mps(state, mesh, integral_type="trapezoidal")
+            if DEBUG:
+                log(f"integral = {integral:.15e}")
+            error = abs(integral - get_error.integral_prev)
+            get_error.integral_prev = integral
+        return error
+
+    mesh_shape = mesh.shape()[:-1]
+    # TODO: Think how to generalize to arbitrary physical dimension
+    base = 2
+    mesh_sites_per_dimension = [int(np.emath.logn(base, s)) for s in mesh_shape]
+    sites = sum(mesh_sites_per_dimension)
+    I_s = [np.array([[0], [1]]) for _ in range(sites)]
+    I_le = [np.array([], dtype=int)] * (sites + 1)
+    if starting_indices is None:
+        rng = np.random.default_rng(seed=42)
+        I_g = random_initial_indices(I_s, starting_bond=1, rng=rng)
+    else:
+        if len(starting_indices) - 1 != sites:
+            raise ValueError("Invalid starting indices")
+        I_g = starting_indices
+
+    errors = []
+    bonds = []
+    evaluations = []
+    times = []
+
+    state = MPS([np.zeros((1, 2, 1))] * sites)  # Placeholder state
+
+    converged = False
+    message = f"Maximum number of sweeps {maxiter} reached"
+    _ones = lambda x: np.ones((x, 1), dtype=int)
+
+    for sweep in range(maxiter):
+        start_time = perf_counter()
+        # Update maxvol rank change based on maxbond
+        if max(A.shape[0] for A in state) < maxbond:
+            rank_change = bond_change
+        else:
+            rank_change = 0
+        evals = 0
+
+        # Forward pass
+        for k in range(sites):
+            fiber = sample_tensor_fiber(
+                func, mesh, mps_ordering, I_le[k], I_s[k], I_g[k + 1]
+            )
+            evals += fiber.size
+            r_le, s, r_g = fiber.shape
+            fiber_matrix = fiber.reshape(r_le * s, r_g, order="F")
+            Q, R = np.linalg.qr(fiber_matrix)
+            maxvol_rows, maxvol_coefs = maxvol(Q, rank_change)
+            state[k] = maxvol_coefs.reshape(r_le, s, -1, order="F")
+            R = Q[maxvol_rows, :] @ R
+            I_fiber_rows = np.hstack(
+                (np.kron(_ones(s), I_le[k]), np.kron(I_s[k], _ones(r_le)))
+            )
+            I_le[k + 1] = I_fiber_rows[maxvol_rows, :]
+        state[k] = np.tensordot(state[k], R, 1)
+
+        # Backward pass
+        for k in reversed(range(sites)):
+            fiber = sample_tensor_fiber(
+                func, mesh, mps_ordering, I_le[k], I_s[k], I_g[k + 1]
+            )
+            evals += fiber.size
+            r_le, s, r_g = fiber.shape
+            fiber_matrix = fiber.reshape(r_le, s * r_g, order="F").T
+            Q, R = np.linalg.qr(fiber_matrix)
+            maxvol_rows, maxvol_coefs = maxvol(Q, rank_change)
+            state[k] = maxvol_coefs.T.reshape(-1, s, r_g, order="F")
+            R = (Q[maxvol_rows, :] @ R).T
+            I_fiber_rows = np.hstack(
+                (np.kron(_ones(r_g), I_s[k]), np.kron(I_g[k + 1], _ones(s)))
+            )
+            I_g[k] = I_fiber_rows[maxvol_rows, :]
+        state[0] = np.tensordot(R, state[0], 1)
+
+        end_time = perf_counter()
+        time = end_time - start_time
+        error = get_error(state)
+        all_bonds = state.bond_dimensions()
+        if DEBUG:
+            log(
+                f"sweep = {sweep:3d}, error = {error:.15e}, maxbond = {max(all_bonds):3d}, evaluations = {evals:8d}, time = {time:5f}"
+            )
+        errors.append(error)
+        bonds.append(all_bonds)
+        evaluations.append(evals)
+        times.append(time)
+
+        if error < tol:
+            message = f"State converged within tolerance {tol}"
+            converged = True
+            break
+
+        if callback is not None:
+            callback(state)
+
+    # Simplify the state according to the strategy
+    state = simplify(state, strategy=strategy)
+    truncated_bonds = state.bond_dimensions()
+    bonds.append(truncated_bonds)
+    if DEBUG:
+        log(
+            f"simplification truncates maxbond from {max(all_bonds)} to {max(truncated_bonds)}"
+        )
+
+    return CrossResults(
+        state=state,
+        converged=converged,
+        message=message,
+        errors=errors,
+        bonds=bonds,
+        evaluations=evaluations,
+        times=times,
+    )

--- a/seemps/analysis/mesh.py
+++ b/seemps/analysis/mesh.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from itertools import product
-from typing import Callable, List, Tuple
+from typing import List, Union, Tuple
 
 import numpy as np
 
@@ -80,59 +80,57 @@ class Mesh:
     def __init__(self, intervals: List[Interval]):
         self.intervals = intervals
         self.dimension = len(intervals)
+        self.transformation_matrix = None
 
-    def __getitem__(self, indices: Tuple[int, ...]):
-        if len(indices) != self.dimension:
-            raise ValueError("Incorrect index size")
-        return np.array(
-            [interval[idx] for interval, idx in zip(self.intervals, indices)]
-        )
+    def __getitem__(self, indices: Union[Tuple[int, ...], np.ndarray]):
+        if isinstance(indices, np.ndarray):
+            indices = np.atleast_2d(indices)
+            if indices.shape[1] != self.dimension:
+                raise ValueError("Incorrect index shape for NumPy array")
+            result = np.empty_like(indices, dtype=float)
+            for i, interval in enumerate(self.intervals):
+                result[:, i] = indices[:, i] * interval.step + interval.start
+            return result[0] if indices.ndim == 1 else result
+
+        elif isinstance(indices, tuple):
+            if len(indices) != self.dimension:
+                raise ValueError("Incorrect number of indices")
+            return np.array(
+                [interval[idx] for interval, idx in zip(self.intervals, indices)]
+            )
+        else:
+            raise TypeError("Indices must be a tuple or NumPy array")
+
+    def binary_transformation_matrix(self, ordering="A", base=2) -> np.ndarray:
+        """
+        Constructs and returns a binary transformation matrix based on the specified ordering and base.
+        """
+        sites = [int(np.emath.logn(base, s)) for s in self.shape()[:-1]]
+        if self.transformation_matrix is None:
+            if ordering == "A":
+                T = np.zeros((sum(sites), len(sites)), dtype=int)
+                start = 0
+                for m, n in enumerate(sites):
+                    T[start : start + n, m] = 2 ** np.arange(n)[::-1]
+                    start += n
+                self.transformation_matrix = T
+            elif ordering == "B":
+                # Strategy: stack diagonal matrices and remove unwanted rows.
+                # TODO: Improve this logic.
+                T = []
+                for i in range(max(sites)):
+                    diagonal = [2 ** (n - i - 1) if n > i else 0 for n in sites]
+                    T.append(np.diag(diagonal))
+                T = np.vstack(T)
+                T = T[~np.all(T <= 0, axis=1)]
+                self.transformation_matrix = T
+        return self.transformation_matrix
 
     def shape(self):
         return tuple(interval.size for interval in self.intervals) + (self.dimension,)
 
     def to_tensor(self):
         return np.array(list(product(*self.intervals))).reshape(self.shape())
-
-
-def mps_indices_to_mesh_indices(
-    mesh: Mesh, mps_indices: np.ndarray, mps_ordering: str = "A"
-) -> np.ndarray:
-    """
-    Converts indices from MPS format to Mesh (decimal) format.
-    If the mesh represents a multivariate domain, the indices
-    depend on the ordering of the MPS.
-
-    Parameters
-    ----------
-    mesh : Mesh
-        The mesh object defining the spatial domain.
-    mps_indices : np.ndarray
-        Array of indices in MPS format.
-    mps_ordering : str, default 'A'
-        The ordering of the MPS, either 'A' or 'B'.
-
-    Returns
-    -------
-    mesh_indices : np.ndarray
-        Array of indices in the mesh corresponding to the MPS indices.
-    """
-
-    bits_to_int = lambda bits: int("".join(map(str, bits)), 2)
-    sites_per_dimension = [int(np.log2(size)) for size in mesh.shape()[:-1]]
-    dims = len(sites_per_dimension)
-    mesh_indices = []
-    for dim, sites in enumerate(sites_per_dimension):
-        if mps_ordering == "A":
-            slice = np.arange(dim * sites, (dim + 1) * sites)
-        elif mps_ordering == "B":
-            slice = np.arange(dim, dims * sites, dims)
-        else:
-            raise ValueError("Invalid mps_ordering")
-        mesh_indices.append(
-            np.array([bits_to_int(bits) for bits in mps_indices[:, slice]])
-        )
-    return np.column_stack(mesh_indices)
 
 
 # TODO: Think if this should be included in the library
@@ -165,10 +163,3 @@ def reorder_tensor(tensor: np.ndarray, sites_per_dimension: List[int]) -> np.nda
     axes = [item for items in axes for item in items]
     tensor = np.transpose(tensor, axes=axes)
     return tensor.reshape(shape_orig)
-
-
-def sample_mesh(
-    func: Callable, mesh: Mesh, mps_indices: np.ndarray, mps_ordering: str
-) -> np.ndarray:
-    mesh_indices = mps_indices_to_mesh_indices(mesh, mps_indices, mps_ordering)
-    return np.array([func(mesh[idx]) for idx in mesh_indices]).flatten()

--- a/seemps/analysis/sampling.py
+++ b/seemps/analysis/sampling.py
@@ -1,0 +1,105 @@
+from typing import Optional, Union
+
+import numpy as np
+
+from seemps.operators import MPO
+from seemps.state import MPS
+
+
+def sample_mps(mps: MPS, mps_indices: np.ndarray) -> np.ndarray:
+    """
+    Returns the samples corresponding to an array of MPS indices.
+
+    Parameters
+    ----------
+    mps : MPS
+        The MPS to sample from.
+    mps_indices : np.ndarray
+        An array of indices to be sampled on the MPS.
+
+    Returns
+    -------
+    samples : np.ndarray
+        The array of samples corresponding to the provided indices."""
+
+    if mps_indices.ndim == 1:
+        mps_indices = mps_indices[np.newaxis, :]
+    reduced_mps = mps[0][0, mps_indices[:, 0], :]
+    for i in range(1, len(mps)):
+        # TODO: Replace einsum by something more efficient
+        reduced_mps = np.einsum(
+            "kq,qkr->kr", reduced_mps, mps[i][:, mps_indices[:, i], :]
+        )
+    samples = reduced_mps[:, 0]
+    return samples
+
+
+def random_mps_indices(
+    mps: MPS, num_indices: int = 1000, rng: Optional[np.random.Generator] = None
+):
+    """
+    Generates random indices for sampling a MPS.
+
+    Parameters
+    ----------
+    mps : MPS
+        The matrix product state to sample from.
+    num_indices : int, default 1000
+        The number of random indices to generate.
+    rng : Optional[np.random.Generator], default None
+        Random number generator instance. If None, a default generator is used.
+
+    Returns
+    -------
+    indices : np.ndarray
+        An array of random MPS indices."""
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return np.vstack([rng.choice(k, num_indices) for k in mps.physical_dimensions()]).T
+
+
+def infinity_norm(tensor_network: Union[MPS, MPO], k_vals: int = 100) -> float:
+    """
+    Finds the infinity norm of a given tensor network.
+    For a MPS, it corresponds to its largest element in absolute value.
+    For a MPO, it corresponds to its operator norm (how much it 'lengthens' MPS).
+
+    Parameters
+    ----------
+    tensor_network : Union[MPS, MPO]
+        The given MPS or MPO to compute the norm.
+    k_vals : int, default 100
+        The number of top values to consider for finding the largest value.
+
+    Returns
+    -------
+    norm : float
+        The infinity norm of the tensor network.
+    """
+    N = len(tensor_network)
+    if isinstance(tensor_network, MPO):
+        mps = tensor_network @ MPS([np.ones((1, 2, 1))] * N)
+    elif isinstance(tensor_network, MPS):
+        mps = tensor_network
+
+    # TODO: Clean up
+    scale_factor = 1 / N
+    _, s, r = mps[0].shape
+    I = np.arange(s).reshape(-1, 1)  # Physical indices of mps[0]
+    reduced_site = mps[0].reshape(s, r) * 2**scale_factor
+    for site in mps[1:]:
+        _, s, r = site.shape
+        # TODO: Replace einsum with a more efficient method
+        reduced_site = np.einsum("kr,riq->kiq", reduced_site, site).reshape(-1, r)
+        I_l = np.kron(I, np.ones((s, 1), dtype=int))
+        I_r = np.kron(np.ones((I.shape[0], 1), dtype=int), np.arange(s).reshape(-1, 1))
+        I = np.hstack((I_l, I_r))
+        norms = np.sum((reduced_site / np.max(np.abs(reduced_site))) ** 2, axis=1)
+        candidates = np.argsort(norms)[: -(k_vals + 1) : -1]
+        I = I[candidates, :]
+        reduced_site = reduced_site[candidates, :] * 2**scale_factor
+    largest_idx = I[0]
+    largest_value = sample_mps(mps, largest_idx)[0]
+    norm = abs(largest_value)
+    return norm

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ from .test_sample_states import *
 from .test_sampling import *
 from .test_random_mps import *
 from .test_canonical import *
+from .test_chebyshev import *
 from .test_circuits import *
 from .test_combine import *
 from .test_contractions import *

--- a/tests/test_chebyshev.py
+++ b/tests/test_chebyshev.py
@@ -1,23 +1,24 @@
 import numpy as np
 from scipy.special import erf
+
 from seemps.analysis import (
     RegularHalfOpenInterval,
-    chebyshev_approximation_clenshaw,
     chebyshev_coefficients,
-    differentiate_chebyshev_coefficients,
-    integrate_chebyshev_coefficients,
+    chebyshev_approximation,
     mps_tensor_sum,
     mps_tensor_product,
     mps_interval,
 )
+from seemps.state import Strategy
+from seemps.operators import MPO
 
 from .tools import TestCase
 
 
-class TestChebyshev(TestCase):
+class TestChebyshevMPS(TestCase):
     def test_chebyshev_coefficients(self):
         f = lambda x: np.exp(x)
-        cheb_coeffs = chebyshev_coefficients(f, -1, 1, 15)
+        cheb_coeffs = chebyshev_coefficients(f, 15, -1, 1)
         correct_coeffs = [
             1.266065877752008,
             1.130318207984970,
@@ -38,63 +39,57 @@ class TestChebyshev(TestCase):
         assert np.allclose(cheb_coeffs, correct_coeffs)
 
     def test_gaussian_1d(self):
-        start = -2
+        start = -1
         stop = 2
         sites = 5
         order = 20
         f = lambda x: np.exp(-(x**2))
-        coefficients = chebyshev_coefficients(f, start, stop, order)
         interval = RegularHalfOpenInterval(start, stop, 2**sites)
-        mps = chebyshev_approximation_clenshaw(
-            coefficients, mps_interval(interval, rescale=True)
-        )
-        self.assertSimilar(f(interval.to_vector()), mps.to_vector())
+        mps_domain = mps_interval(interval)
+        mps_cheb = chebyshev_approximation(f, order, mps_domain)
+        self.assertSimilar(f(interval.to_vector()), mps_cheb.to_vector())
 
-    def test_gaussian_1d_derivative(self):
+    def test_gaussian_derivative_1d(self):
         start = -1
-        stop = 3
+        stop = 2
         sites = 5
-        order = 25
+        order = 22
         f = lambda x: np.exp(-(x**2))
         f_diff = lambda x: -2 * x * np.exp(-(x**2))
-        coefficients = differentiate_chebyshev_coefficients(
-            chebyshev_coefficients(f, start, stop, order), start, stop
-        )
         interval = RegularHalfOpenInterval(start, stop, 2**sites)
-        mps = chebyshev_approximation_clenshaw(
-            coefficients, mps_interval(interval, rescale=True)
+        mps_domain = mps_interval(interval)
+        mps_cheb = chebyshev_approximation(
+            f, order, mps_domain, differentiation_order=1
         )
-        self.assertSimilar(f_diff(interval.to_vector()), mps.to_vector())
+        self.assertSimilar(f_diff(interval.to_vector()), mps_cheb.to_vector())
 
-    def test_gaussian_1d_integral(self):
+    def test_gaussian_integral_1d(self):
         def equal_up_to_constant(arr1, arr2):
             difference = arr1 - arr2
             return np.allclose(difference, difference[0])
 
-        start = -2
+        start = -1
         stop = 2
         sites = 5
         order = 20
         f = lambda x: np.exp(-(x**2))
-        f_intg = lambda x: np.sqrt(np.pi) / 2 * erf(x)
-        coefficients = integrate_chebyshev_coefficients(
-            chebyshev_coefficients(f, start, stop, order), start, stop
-        )
+        f_intg = lambda x: (np.sqrt(np.pi) / 2) * erf(x)
         interval = RegularHalfOpenInterval(start, stop, 2**sites)
-        mps = chebyshev_approximation_clenshaw(
-            coefficients, mps_interval(interval, rescale=True)
+        mps_domain = mps_interval(interval)
+        mps_cheb = chebyshev_approximation(
+            f, order, mps_domain, differentiation_order=-1
         )
-        assert equal_up_to_constant(f_intg(interval.to_vector()), mps.to_vector())
+        assert equal_up_to_constant(f_intg(interval.to_vector()), mps_cheb.to_vector())
 
     def test_tensor_product(self):
-        start = -2
+        start = -1
         stop = 2
         sites = 5
         interval = RegularHalfOpenInterval(start, stop, 2**sites)
         vector = interval.to_vector()
-        mps = mps_interval(interval)
-        mps_tensor = mps_tensor_product([mps, mps])
-        Z_mps = mps_tensor.to_vector().reshape((2**sites, 2**sites))
+        mps_intv = mps_interval(interval)
+        mps_domain = mps_tensor_product([mps_intv, mps_intv])
+        Z_mps = mps_domain.to_vector().reshape((2**sites, 2**sites))
         X, Y = np.meshgrid(vector, vector)
         self.assertSimilar(Z_mps, X * Y)
 
@@ -104,8 +99,56 @@ class TestChebyshev(TestCase):
         sites = 5
         interval = RegularHalfOpenInterval(start, stop, 2**sites)
         vector = interval.to_vector()
-        mps = mps_interval(interval)
-        mps_tensor = mps_tensor_sum([mps, mps])
-        Z_mps = mps_tensor.to_vector().reshape((2**sites, 2**sites))
+        mps_intv = mps_interval(interval)
+        mps_domain = mps_tensor_sum([mps_intv, mps_intv])
+        Z_mps = mps_domain.to_vector().reshape((2**sites, 2**sites))
         X, Y = np.meshgrid(vector, vector)
         self.assertSimilar(Z_mps, X + Y)
+
+    def test_gaussian_2d(self):
+        start = -1
+        stop = 2
+        sites = 5
+        order = 40
+        interval = RegularHalfOpenInterval(start, stop, 2**sites)
+        vector = interval.to_vector()
+        func = lambda x: np.exp(-(x**2))
+        t = 1e-15
+        strategy = Strategy(tolerance=t, simplification_tolerance=t)
+        mps_intv = mps_interval(interval)
+        mps_domain = mps_tensor_sum([mps_intv, mps_intv])
+        mps_cheb = chebyshev_approximation(func, order, mps_domain, strategy=strategy)
+        Z_mps = mps_cheb.to_vector().reshape((2**sites, 2**sites))
+        X, Y = np.meshgrid(vector, vector)
+        Z_vector = func(X + Y)
+        self.assertSimilar(Z_mps, Z_vector)
+
+
+class TestChebyshevMPO(TestCase):
+    pass
+    # def test_gaussian_on_diagonal_mpo(self):
+    #     start = -1
+    #     stop = 2
+    #     sites = 5
+    #     order = 10
+    #     f = lambda x: np.exp(-(x**2))
+    #     mpo_domain = position_mpo(start, stop, sites)
+    #     mpo_cheb = chebyshev_approximation(f, order, mpo_domain)
+
+
+def position_mpo(a, b, n):
+    left_tensor = np.zeros((1, 2, 2, 2))
+    right_tensor = np.zeros((2, 2, 2, 1))
+    middle_tensors = [np.zeros((2, 2, 2, 2)) for _ in range(n - 2)]
+    dx = (b - a) / 2**n
+    left_tensor[0, :, :, 0] = np.eye(2)
+    left_tensor[0, :, :, 1] = np.array([[a, 0], [0, a + dx * 2 ** (n - 1)]])
+    right_tensor[1, :, :, 0] = np.eye(2)
+    right_tensor[0, :, :, 0] = np.array([[0, 0], [0, dx]])
+    for i in range(len(middle_tensors)):
+        middle_tensors[i][0, :, :, 0] = np.eye(2)
+        middle_tensors[i][1, :, :, 1] = np.eye(2)
+        middle_tensors[i][0, :, :, 1] = np.array([[0, 0], [0, dx * 2 ** (n - (i + 2))]])
+    tensors = [left_tensor] + middle_tensors + [right_tensor]
+    mpo = MPO(tensors)
+    return mpo

--- a/tests/test_cross_new.py
+++ b/tests/test_cross_new.py
@@ -1,0 +1,79 @@
+import numpy as np
+from seemps.analysis import (
+    Mesh,
+    RegularHalfOpenInterval,
+    cross_interpolation,
+    sample_initial_indices,
+    reorder_tensor,
+)
+from seemps.state import MPS
+from seemps.truncate import simplify, SIMPLIFICATION_STRATEGY
+
+from .tools import TestCase
+
+
+class TestCrossInterpolation(TestCase):
+    @staticmethod
+    def gaussian_setup(dims, n=5, a=-1, b=1):
+        func = lambda vec: np.exp(-(np.sum(vec, axis=-1) ** 2))
+        intervals = [RegularHalfOpenInterval(a, b, 2**n) for _ in range(dims)]
+        mesh = Mesh(intervals)
+        mesh_tensor = mesh.to_tensor()
+        func_vector = func(mesh_tensor).reshape(-1)
+        mps = MPS.from_vector(func_vector, [2] * (n * dims), normalize=False)
+        return func, mesh, mps, func_vector
+
+    # 1D Gaussian
+    def test_cross_1d_from_random(self):
+        func, mesh, _, func_vector = self.gaussian_setup(1)
+        cross_results = cross_interpolation(func, mesh)
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    def test_cross_1d_from_mps(self):
+        func, mesh, mps0, func_vector = self.gaussian_setup(1)
+        starting_indices = sample_initial_indices(mps0)
+        cross_results = cross_interpolation(
+            func, mesh, starting_indices=starting_indices
+        )
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    def test_cross_1d_with_measure_norm(self):
+        func, mesh, _, func_vector = self.gaussian_setup(1)
+        cross_results = cross_interpolation(func, mesh, error_type="norm")
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    def test_cross_1d_with_measure_integral(self):
+        func, mesh, _, func_vector = self.gaussian_setup(1)
+        cross_results = cross_interpolation(func, mesh, error_type="integral")
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    def test_cross_1d_simplified(self):
+        func, mesh, _, _ = self.gaussian_setup(1)
+        cross_results = cross_interpolation(func, mesh)
+        mps = cross_results.state
+        mps_simplified = simplify(
+            mps,
+            strategy=SIMPLIFICATION_STRATEGY.replace(normalize=False),
+        )
+        self.assertSimilar(mps_simplified.to_vector(), mps.to_vector())
+
+    def test_cross_1d_norm2_error(self):
+        func, mesh, mps0, func_vector = self.gaussian_setup(1)
+        starting_indices = sample_initial_indices(mps0)
+        cross_results = cross_interpolation(
+            func, mesh, starting_indices=starting_indices, error_type="norm"
+        )
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    # 2D Gaussian
+    def test_cross_2d_from_random(self):
+        func, mesh, _, func_vector = self.gaussian_setup(2)
+        cross_results = cross_interpolation(func, mesh)
+        self.assertSimilar(func_vector, cross_results.state.to_vector())
+
+    def test_cross_2d_with_ordering_B(self):
+        func, mesh, _, func_vector = self.gaussian_setup(2)
+        cross_results = cross_interpolation(func, mesh, mps_ordering="B")
+        qubits = [int(np.log2(s)) for s in mesh.shape()[:-1]]
+        tensor = reorder_tensor(cross_results.state.to_vector(), qubits)
+        self.assertSimilar(func_vector, tensor)


### PR DESCRIPTION
@juanjosegarciaripoll 
Te dejo unos cambios que he hecho sobretodo sobre cross.py, incorporando tus recomendaciones.
La historia de commits está un poco desorganizada ya que tengo cambios tanto de `cross` como `chebyshev` y no sé como separarlos en dos PR independientes. Además, para Mesh hay commits con cambios contrarios que no sé como unificar. 

Cambios:
1. Simplificación de la estructura de cross:
- Organizar en funciones desacopladas. Creo que ahora es bastante más fácil de entender.
- Documentación de estas funciones.
- Eliminar la dependencia en un estado inicial `mps_0` en favor de un argumento `starting_indices` que se puede crear con una función auxiliar `sample_initial_indices(state)`. Por defecto, índices aleatorios con `bond_dimension` 1.
- Eliminar la dependencia en `CrossStrategy` en favor de argumentos en `cross_interpolation`.
- Eliminar función `skeleton_decomposition`, absorbiéndola en los sweeps de `cross_interpolation`.
- Unificar antiguos `cross/cross.py` y `cross/maxvol.py` en `analysis/cross.py`.
- Eliminar funcionalidad de interpolar sobre TT, ya que para esto tenía que implementar una lógica adicional para comparar los sitios del `mps_0` con los de `mesh` a través de un argumento `structure`.
- Modificar estructura de función `cross_interpolation`, emulando la estructura de otros algoritmos de la librería. Por ejemplo, devolviendo un dataclass `CrossResults` con trayectorias al final del algoritmo.
- Incorporación de evaluación de error mediante diferencias en integral con cuadratura trapezoidal.

Por la cantidad de cambios, he creado un nuevo archivo `analysis/cross.py` y módulo de tests `test_cross_new.py` sin eliminar los anteriores.

2. Optimización de cross
- Añadir matrices binarias de transformación para pasar de índices de MPS a índices de malla con órdenes 'A' o 'B'.
- Permitir indexación de una `mesh` con numpy arrays en lugar de tuplas para facilitar vectorización.
- Añadir simplificación con una `Strategy` al final del algoritmo.
- No he hecho un benchmark pero diría que es aproximadamente el doble de rápido.

3. Añadir módulo `analysis/sampling`.
- Este módulo incorpora funcionalidad para samplear un MPS, crear índices de MPS aleatorios y calcular la norma-infinito de un MPS o MPO mediante el método probabilístico que te comenté, que parece que va muy bien. Uso esta norma infinito para normalizar el dominio de Chebyshev.

4. Modificar Chebyshev.
- Planteamiento del algoritmo de Chebyshev para un dominio MPS/MPO arbitrario normalizándolo con su norma infinito (tengo que cambiarlo en favor de unos argumentos `start` y `stop` como hablamos).

