### PR TITLE
Allow call to simplification with strategy NO_TRUNCATION

### DIFF
--- a/src/seemps/truncate/simplify.py
+++ b/src/seemps/truncate/simplify.py
@@ -167,21 +167,21 @@ def guess_combine_state(weights: list, states: list[MPS]) -> MPS:
         DL, d, DR = sumA.shape
         a, d, b = A.shape
         if idx == 0:
-            new_A = np.zeros((d, DR + b))
+            new_A = np.zeros((d, DR + b), dtype=sumA.dtype)
             for d_i in range(d):
                 new_A[d_i, :] = np.concatenate(
                     (sumA.reshape(d, DR)[d_i, :], A.reshape(d, b)[d_i, :])
                 )
             new_A = new_A.reshape(1, d, DR + b)
         elif idx == -1:
-            new_A = np.zeros((DL + a, d))
+            new_A = np.zeros((DL + a, d), dtype=sumA.dtype)
             for d_i in range(d):
                 new_A[:, d_i] = np.concatenate(
                     (sumA.reshape(DL, d)[:, d_i], A.reshape(a, d)[:, d_i])
                 )
             new_A = new_A.reshape(DL + a, d, 1)
         else:
-            new_A = np.zeros((DL + a, d, DR + b))
+            new_A = np.zeros((DL + a, d, DR + b), dtype=sumA.dtype)
             for d_i in range(d):
                 new_A[:, d_i, :] = scipy.linalg.block_diag(
                     sumA[:, d_i, :], A[:, d_i, :]

--- a/src/seemps/truncate/simplify.py
+++ b/src/seemps/truncate/simplify.py
@@ -237,6 +237,8 @@ def combine(
     if guess is None:
         if strategy.get_simplification_method() == Simplification.CANONICAL_FORM:
             mps = guess_combine_state(weights, states)
+        elif strategy.get_simplification_method() == Simplification.DO_NOT_SIMPLIFY:
+            mps = guess_combine_state(weights, states)
         elif strategy.get_simplification_method() == Simplification.VARIATIONAL:
             mps = crappy_guess_combine_state(weights, states)
     else:

--- a/src/seemps/truncate/simplify.py
+++ b/src/seemps/truncate/simplify.py
@@ -53,8 +53,6 @@ def simplify(
     CanonicalMPS
         Approximation :math:`\\xi` to the state.
     """
-    if strategy.get_simplification_method() == Simplification.DO_NOT_SIMPLIFY:
-        raise ValueError("Not valid simplification method.")
     if isinstance(state, MPSSum):
         return combine(
             state.weights,


### PR DESCRIPTION
Currently, the `NO_TRUNCATION` strategy will raise an error in some contexts (e.g. when passed to the `runge_kutta` or other integrators from `seemps.evolution`). This is because the function `simplify` is called within those routines, and it is currently set to raise an error for `NO_TRUNCATION`.

This PR intends to permit simplification with `NO_TRUNCATION`. It consists of 3 commits:

1. Remove error raised on `simplify()` when the strategy is `NO_TRUNCATION`
2. Add a case in `combine()` to generate the guess for the simplification method `DO_NOT_SIMPLIFY`
3. Somewhat less related to the rest of the pull request:  On `guess_combine_state()`, do not assume the tensors are real.

@juanjosegarciaripoll 