### PR TITLE
Add function for HDAF split-step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ arises from the following works on quantum-inspired algorithms for numerical ana
 - *Chebyshev approximation and composition of functions in matrix product states for quantum-inspired numerical analysis*,
   Juan José Rodríguez-Aldavero, Paula García-Molina, Luca Tagliacozzo, Juan José García-Ripoll
   https://arxiv.org/abs/2407.09609
+  
+- *Pseudospectral method for solving PDEs using matrix product states*,
+  Jorge Gidi, Paula García-Molina, Luca Tagliacozzo, Juan José García-Ripoll
+  https://arxiv.org/abs/2409.02916
 
 ## Usage
 

--- a/src/seemps/analysis/hdaf.py
+++ b/src/seemps/analysis/hdaf.py
@@ -12,12 +12,12 @@ from ..typing import FloatOrArray, Float
 
 
 def auto_sigma(
-    M: int, dx: Float, time: Float = 0.0, lower_bound: Float | None = None
+    M: int, dx: Float, time: Float | complex = 0.0, lower_bound: Float | None = None
 ) -> Float:
     if lower_bound is None:
         lower_bound = 3 * dx
     s0: Float = hdaf_kernel(0, dx=dx, s0=1.0, M=M)
-    return max(float(lower_bound), sqrt(abs(time)), s0)  # type: ignore
+    return max(float(lower_bound), sqrt(abs(time)), float(s0))  # type: ignore
 
 
 def _asymptotic_factor(M: int, l: int, c: Float) -> Float:
@@ -29,33 +29,35 @@ def _asymptotic_factor(M: int, l: int, c: Float) -> Float:
     return np.exp(0.5 * loggamma(M + l + 1) + Mhalf * np.log(c) - loggamma(Mhalf + 1))
 
 
-def _width_bound(s0: Float, M: int, l: int, time: Float, eps: Float = 1e-16) -> Float:
+def _width_bound(
+    s0: Float, M: int, l: int, time: Float | complex, eps: Float = 1e-16
+) -> Float:
     r"""
     Analytic upper bound for the width of the HDAF with the same given
     parameters.
 
     Returns a value xb such that :math:`|HDAF(x)| < \mathrm{eps}`, for :math:`|x| >= xb`.
     """
-    st2 = s0**2 + 1j * time
-    abs_st = abs(st2) ** 0.5
+    st2 = complex(s0**2 + 1j * time)
+    abs_st = float(abs(st2)) ** 0.5
     inv_st2 = 1.0 / st2
 
     A = 0.5 * np.real(inv_st2)
     B = -sqrt(M + l) / abs_st
 
     chi = _asymptotic_factor(M, l, c=0.5 * abs(s0 / abs_st) ** 2)
-    chi /= sqrt(2 * np.pi) * abs_st ** (l + 1)
+    chi /= sqrt(2 * np.pi) * abs_st ** (l + 1)  # type: ignore
 
-    C = log(eps / chi)
+    C = log(eps / abs(chi))
 
     return 0.5 * (-B + sqrt(B**2 - 4 * A * C)) / A
 
 
 def _hnl(
     x: np.ndarray,
-    c: Float = 1.0,
+    c: Float | complex = 1.0,
     l: int = 0,
-    d: Float = 1.0,
+    d: Float | complex | np.ndarray = 1.0,
 ) -> Iterator[np.ndarray]:
     """
     Generator for H(2n + l, x) * c**n * d / factorial(n), without explicitly
@@ -64,7 +66,7 @@ def _hnl(
     """
 
     n = 0
-    hn = np.ones(x.shape) * d  # H0 with appropriate shape
+    hn: np.ndarray = np.ones(x.shape) * d  # H0 with appropriate shape
     gn = 2 * x * d  # H1
 
     # Compute initial values
@@ -89,7 +91,7 @@ def hdaf_kernel(
     dx: Float,
     s0: Float,
     M: int,
-    time: Float = 0.0,
+    time: Float | complex = 0.0,
     derivative: int = 0,
 ) -> FloatOrArray:
     if time == 0:  # Spread under the free propagator
@@ -111,7 +113,7 @@ def hdaf_mpo(
     dx: Float,
     M: int,
     s0: Float | None = None,
-    time: Float = 0.0,
+    time: Float | complex = 0.0,
     derivative: int = 0,
     periodic: bool = True,
     strategy: Strategy = DEFAULT_STRATEGY,

--- a/src/seemps/analysis/hdaf.py
+++ b/src/seemps/analysis/hdaf.py
@@ -17,7 +17,7 @@ def auto_sigma(
     if lower_bound is None:
         lower_bound = 3 * dx
     s0: Float = hdaf_kernel(0, dx=dx, s0=1.0, M=M)
-    return max(float(lower_bound), sqrt(time), s0)  # type: ignore
+    return max(float(lower_bound), sqrt(abs(time)), s0)  # type: ignore
 
 
 def _asymptotic_factor(M: int, l: int, c: Float) -> Float:
@@ -36,12 +36,14 @@ def _width_bound(s0: Float, M: int, l: int, time: Float, eps: Float = 1e-16) -> 
 
     Returns a value xb such that :math:`|HDAF(x)| < \mathrm{eps}`, for :math:`|x| >= xb`.
     """
-    abs_st = (s0**4 + time**2) ** 0.25
+    st2 = s0**2 + 1j * time
+    abs_st = abs(st2) ** 0.5
+    inv_st2 = 1.0 / st2
 
-    A = 0.5 / (s0**2 + (time / s0) ** 2)
+    A = 0.5 * np.real(inv_st2)
     B = -sqrt(M + l) / abs_st
 
-    chi = _asymptotic_factor(M, l, c=0.5 * (s0 / abs_st) ** 2)
+    chi = _asymptotic_factor(M, l, c=0.5 * abs(s0 / abs_st) ** 2)
     chi /= sqrt(2 * np.pi) * abs_st ** (l + 1)
 
     C = log(eps / chi)

--- a/src/seemps/evolution/hdaf.py
+++ b/src/seemps/evolution/hdaf.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+import numpy as np
+from typing import Callable, Any
+from ..state import MPS, Strategy, DEFAULT_STRATEGY
+from ..state.simplification import simplify
+from ..analysis.mesh import Mesh, QuantizedInterval, mps_to_mesh_matrix
+from ..analysis.cross.black_box import BlackBoxLoadMPS
+from ..analysis.cross.cross_dmrg import cross_dmrg, CrossStrategyDMRG
+from ..analysis.hdaf import hdaf_mpo
+from .common import ode_solver, ODECallback, TimeSpan
+
+
+def split_step(
+    potential_func: Callable[[np.ndarray], np.ndarray],
+    time: TimeSpan,
+    state: MPS,
+    a: float,
+    num_qubits: int,
+    dx: float,
+    periodic: bool,
+    steps: int = 1000,
+    strategy: Strategy = DEFAULT_STRATEGY,
+    callback: ODECallback | None = None,
+    hdaf_order: int = 30,
+    itime: bool = False,
+) -> MPS | list[Any]:
+    """
+    Implements a second-order Strang splitting time evolution for a Hamiltonian :math:`H = -\\frac{1}{2}\\frac{d^2}{dx^2} + V(x)`.
+
+    Parameters
+    ----------
+    potential_func : Callable[[np.ndarray], np.ndarray]
+        A function representing V(x).
+    time : TimeSpan
+        Integration interval. Only constant time steps (float or tuple) are supported.
+    state : MPS
+        The initial MPS wavefunction.
+    a : float
+        Start of the interval.
+    num_qubits : int
+        Number of qubits for the discretization.
+    dx : float
+        Step size.
+    periodic : bool
+        If True, the interval is open [a, b) (Periodic BCs).
+        If False, it is closed [a, b] (Closed BCs).
+    steps : int, default=1000
+        Number of time steps.
+    strategy : Strategy
+        Truncation strategy for MPS simplification.
+    callback : ODECallback | None
+        Function called after each step.
+    hdaf_order : int, default=30
+        Order of the HDAF approximation for the kinetic propagator.
+    itime : bool, default=False
+        Whether to perform imaginary time evolution.
+
+    Returns
+    -------
+    MPS | list[Any]
+        The evolved state or callback results.
+    """
+    # Build space
+    size = 2**num_qubits
+    if periodic:
+        b = a + dx * size
+    else:
+        b = a + dx * (size - 1)
+
+    interval = QuantizedInterval(a, b, num_qubits, endpoint_right=not periodic)
+    mesh = Mesh([interval])
+
+    if itime:
+        factor = 1.0
+    else:
+        factor = 1j
+
+    # Determine dt and steps
+    if isinstance(time, (float, int)):
+        start, stop = 0.0, float(time)
+    elif isinstance(time, tuple):
+        start, stop = float(time[0]), float(time[1])
+    else:
+        raise ValueError(
+            "split_step only supports constant time steps (float or tuple)."
+        )
+
+    dt = (stop - start) / steps
+
+    # Potential Propagator exp(-factor * V(x) * dt / 2)
+    def propagator_func(x):
+        return np.exp(-factor * potential_func(x) * dt / 2)
+
+    physical_dimensions = [2] * num_qubits
+    map_matrix = mps_to_mesh_matrix([num_qubits], base=2)
+    black_box = BlackBoxLoadMPS(propagator_func, mesh, map_matrix, physical_dimensions)
+    cross_results = cross_dmrg(black_box, CrossStrategyDMRG())
+    U_potential_mps = cross_results.mps
+
+    # Kinetic Propagator exp(-factor * T * dt) with T = -0.5 * d^2/dx^2
+    if isinstance(factor, complex) and factor.imag != 0:
+        hdaf_time = dt  # Imaginary time
+    else:
+        hdaf_time = -1j * dt  # Real time
+
+    U_kinetic_mpo = hdaf_mpo(
+        num_qubits=num_qubits,
+        dx=dx,
+        M=hdaf_order,
+        time=hdaf_time,
+        derivative=0,
+        periodic=periodic,
+        strategy=strategy,
+    )
+
+    def evolve_for_dt(
+        t: float,
+        state: MPS,
+        factor: complex | float,
+        dt_step: float,
+        strategy: Strategy,
+    ) -> MPS:
+        # Apply half-step potential
+        state = U_potential_mps * state
+        state = simplify(state, strategy)
+
+        # Apply full-step kinetic
+        state = U_kinetic_mpo @ state
+        state = simplify(state, strategy)
+
+        # Apply half-step potential
+        state = U_potential_mps * state
+        state = simplify(state, strategy)
+
+        return state
+
+    return ode_solver(evolve_for_dt, time, state, steps, strategy, callback, itime)

--- a/src/seemps/evolution/hdaf.py
+++ b/src/seemps/evolution/hdaf.py
@@ -71,7 +71,7 @@ def split_step(
     mesh = Mesh([interval])
 
     if itime:
-        factor = 1.0
+        factor: complex | float = 1.0
     else:
         factor = 1j
 
@@ -98,6 +98,7 @@ def split_step(
     U_potential_mps = cross_results.mps
 
     # Kinetic Propagator exp(-factor * T * dt) with T = -0.5 * d^2/dx^2
+    hdaf_time: complex | float
     if isinstance(factor, complex) and factor.imag != 0:
         hdaf_time = dt  # Imaginary time
     else:

--- a/tests/test_evolution/test_split_step.py
+++ b/tests/test_evolution/test_split_step.py
@@ -1,0 +1,93 @@
+import numpy as np
+from ..tools import TestCase
+from seemps.state import MPS, Strategy
+from seemps.evolution.hdaf import split_step
+
+
+class TestSplitStep(TestCase):
+    def test_analytical_evolution(self):
+        num_qubits = 8
+        dx = 0.1
+        a = -dx * 2 ** (num_qubits - 1)
+        periodic = True
+
+        def potential_func(x):
+            return 0.5 * x**2
+
+        sigma0 = 0.5
+        size = 2**num_qubits
+        x = np.linspace(a, a + dx * size, size, endpoint=False)
+        psi = np.exp(-0.5 * (x / sigma0) ** 2)
+        psi /= np.linalg.norm(psi)
+        state = MPS.from_vector(psi, [2] * num_qubits)
+
+        strategy = Strategy(tolerance=1e-10)
+        final_time = 2.0
+        steps = 20
+
+        final_state = split_step(
+            potential_func=potential_func,
+            time=final_time,
+            state=state,
+            a=a,
+            num_qubits=num_qubits,
+            dx=dx,
+            periodic=periodic,
+            steps=steps,
+            strategy=strategy,
+            itime=False,
+        )
+
+        # Analytical solution
+        A0 = 1.0 / (sigma0**2)
+        ct = np.cos(final_time)
+        st = np.sin(final_time)
+        denom = ct + 1j * A0 * st
+        At = (A0 * ct + 1j * st) / denom
+        psi_exact = np.exp(-0.5 * At * x**2)
+        psi_exact /= np.linalg.norm(psi_exact)
+
+        overlap = abs(np.vdot(psi_exact, final_state.to_vector()))
+        self.assertGreater(overlap, 0.999)
+
+    def test_harmonic_oscillator_imaginary_time(self):
+        num_qubits = 8
+        dx = 0.1
+        a = -dx * 2 ** (num_qubits - 1)
+        periodic = True
+
+        def potential_func(x):
+            return 0.5 * x**2
+
+        # Ground state to compare
+        size = 2**num_qubits
+        x = np.linspace(a, a + dx * size, size, endpoint=False)
+        gs = np.exp(-0.5 * x**2)
+        gs /= np.linalg.norm(gs)
+        gs_mps = MPS.from_vector(gs, [2] * num_qubits)
+
+        # Displaced initial state
+        psi = np.exp(-0.5 * (x - 2.0) ** 2)
+        psi /= np.linalg.norm(psi)
+        state = MPS.from_vector(psi, [2] * num_qubits)
+
+        strategy = Strategy(tolerance=1e-10)
+        final_time = 5.0
+        steps = 50
+
+        final_state = split_step(
+            potential_func=potential_func,
+            time=final_time,
+            state=state,
+            a=a,
+            num_qubits=num_qubits,
+            dx=dx,
+            periodic=periodic,
+            steps=steps,
+            strategy=strategy,
+            itime=True,
+        )
+
+        final_state = final_state.normalize_inplace()
+        overlap = abs(final_state.to_vector() @ gs_mps.to_vector())
+        self.assertGreater(overlap, 0.999)


### PR DESCRIPTION
This PR adds a `seemps.evolution.hdaf.split_step` function. Note that its signature differs from other functions in `seemps.evolution`, as it requires the potential V(x) as a function, as well as parameters specifying the space domain, which is assumed 1-dimensional.

The PR also adds a reference to the "Pseudospectral method for solving PDEs using matrix product states" paper to the README.