### PR TITLE
Set default HDAF order M=10

### DIFF
--- a/src/seemps/analysis/derivatives/hdaf_differentiation.py
+++ b/src/seemps/analysis/derivatives/hdaf_differentiation.py
@@ -8,7 +8,7 @@ from ..hdaf import hdaf_mpo
 def hdaf_derivative_mpo(
     order: int,
     interval: QuantizedInterval | IntervalTuple,
-    M: int = 6,
+    M: int = 10,
     s0: Float | None = None,
     periodic: bool = True,
     strategy: Strategy = DEFAULT_STRATEGY,
@@ -29,7 +29,7 @@ def hdaf_derivative_mpo(
         Whether the grid follows perioidic boundary conditions.
     M : int
         The order of the highest Hermite polynomial (must be an even integer).
-        Defaults to 6.
+        Defaults to 10.
     s0 : Float | None, default=None
         The width of the HDAF Gaussian weight. If not provided, a suitable
         width will be computed based on `M` and `dx`.

--- a/src/seemps/analysis/hdaf.py
+++ b/src/seemps/analysis/hdaf.py
@@ -108,11 +108,10 @@ def hdaf_kernel(
     return cast(FloatOrArray, sum(next(gen) for _ in range(int(M) // 2 + 1)))
 
 
-# TODO: Which "M" should users use? Any sensible default value?
 def hdaf_mpo(
     num_qubits: int,
     dx: Float,
-    M: int,
+    M: int = 10,
     s0: Float | None = None,
     time: Float | complex = 0.0,
     derivative: int = 0,
@@ -131,7 +130,7 @@ def hdaf_mpo(
         The number of qubits to discretize the system.
     dx : Float
         The grid stepsize.
-    M : int
+    M : int, default=10
         The order of the highest Hermite polynomial (must be an even integer).
     s0 : Float | None, default=None
         The width of the HDAF Gaussian weight. If not provided, a suitable

--- a/src/seemps/evolution/hdaf.py
+++ b/src/seemps/evolution/hdaf.py
@@ -21,7 +21,7 @@ def split_step(
     steps: int = 1000,
     strategy: Strategy = DEFAULT_STRATEGY,
     callback: ODECallback | None = None,
-    hdaf_order: int = 30,
+    hdaf_order: int = 10,
     itime: bool = False,
 ) -> MPS | list[Any]:
     """
@@ -50,7 +50,7 @@ def split_step(
         Truncation strategy for MPS simplification.
     callback : ODECallback | None
         Function called after each step.
-    hdaf_order : int, default=30
+    hdaf_order : int, default=10
         Order of the HDAF approximation for the kinetic propagator.
     itime : bool, default=False
         Whether to perform imaginary time evolution.


### PR DESCRIPTION
In this PR, HDAF applications (differentiation, split-step evolution, etc.) are set to use a sensible default order `M=10`.

P.S. Happy 100th PR!