### PR TITLE
Separate QuadraticForm from DMRG

### DIFF
--- a/src/seemps/evolution/tdvp.py
+++ b/src/seemps/evolution/tdvp.py
@@ -1,37 +1,16 @@
 from __future__ import annotations
 
 import numpy as np
-from scipy.sparse.linalg import expm_multiply
+from scipy.sparse.linalg import LinearOperator, expm_multiply
 from seemps.state import MPS, CanonicalMPS, Strategy, DEFAULT_STRATEGY
 from seemps.cython import _contract_last_and_first
-from seemps.optimization.dmrg import (
-    QuadraticForm,
-    DMRGMatrixOperator,
-    OneSiteDMRGOperator,
-)
 from seemps.operators import MPO
+from seemps.operators.quadratic import QuadraticForm
 from seemps.evolution.common import ode_solver, ODECallback, TimeSpan
 
 
-class TDVPForm(QuadraticForm):
-    def one_site_Hamiltonian(self, i: int) -> OneSiteDMRGOperator:
-        return OneSiteDMRGOperator(  # pyright: ignore[reportCallIssue]
-            self.left_env[i],  # pyright: ignore[reportArgumentType]
-            self.H[i],  # pyright: ignore[reportArgumentType]
-            self.right_env[i],  # pyright: ignore[reportArgumentType]
-        )
-
-    def two_site_Hamiltonian(self, i: int) -> DMRGMatrixOperator:
-        assert i == self.site
-        return DMRGMatrixOperator(  # pyright: ignore[reportCallIssue]
-            self.left_env[i],  # pyright: ignore[reportArgumentType]
-            _contract_last_and_first(self.H[i], self.H[i + 1]),  # pyright: ignore[reportArgumentType]
-            self.right_env[i + 1],  # pyright: ignore[reportArgumentType]
-        )
-
-
 def _evolve(
-    operator: OneSiteDMRGOperator | DMRGMatrixOperator,
+    operator: LinearOperator,
     tensor: np.ndarray,
     factor: float | complex,
     normalize: bool = False,
@@ -39,7 +18,7 @@ def _evolve(
     """Apply time evolution operator to tensor."""
     shape = tensor.shape
     v = expm_multiply(
-        factor * operator, tensor.ravel(), traceA=factor * operator.trace()
+        factor * operator, tensor.ravel(), traceA=factor * operator.trace()  # type: ignore[attr-defined]
     )
     if normalize:
         v = v / np.linalg.norm(v)
@@ -53,33 +32,33 @@ def tdvp_step(
     if not isinstance(state, CanonicalMPS):
         state = CanonicalMPS(state, center=0, strategy=strategy)
 
-    QF = TDVPForm(H, state, start=0)
+    QF = QuadraticForm(H, state, start=0)
     normalize = strategy.get_normalize_flag()
 
     # Sweep Right
     for i in range(H.size - 1):
         # Evolve 2-site
-        Op2 = QF.two_site_Hamiltonian(i)
+        Op2 = QF.two_site_operator(i)
         A2 = _contract_last_and_first(QF.state[i], QF.state[i + 1])
         A2 = _evolve(Op2, A2, -0.5 * dt, normalize)
         QF.update_2site_right(A2, i, strategy)
 
         # Evolve 1-site backward
         if i < H.size - 2:
-            Op1 = QF.one_site_Hamiltonian(i + 1)
+            Op1 = QF.one_site_operator(i + 1)
             QF.state[i + 1] = _evolve(Op1, QF.state[i + 1], 0.5 * dt, normalize)
 
     # Sweep Left
     for i in range(H.size - 2, -1, -1):
         # Evolve 2-site
-        Op2 = QF.two_site_Hamiltonian(i)
+        Op2 = QF.two_site_operator(i)
         A2 = _contract_last_and_first(QF.state[i], QF.state[i + 1])
         A2 = _evolve(Op2, A2, -0.5 * dt, normalize)
         QF.update_2site_left(A2, i, strategy)
 
         # Evolve 1-site backward
         if i > 0:
-            Op1 = QF.one_site_Hamiltonian(i)
+            Op1 = QF.one_site_operator(i)
             QF.state[i] = _evolve(Op1, QF.state[i], 0.5 * dt, normalize)
 
     return QF.state

--- a/src/seemps/evolution/tdvp.py
+++ b/src/seemps/evolution/tdvp.py
@@ -17,9 +17,9 @@ def _evolve(
 ) -> np.ndarray:
     """Apply time evolution operator to tensor."""
     shape = tensor.shape
-    v = expm_multiply(
-        factor * operator, tensor.ravel(), traceA=factor * operator.trace()  # type: ignore[attr-defined]
-    )
+    operator_trace = getattr(operator, "trace", None)
+    traceA = None if operator_trace is None else factor * operator_trace()
+    v = expm_multiply(factor * operator, tensor.ravel(), traceA=traceA)
     if normalize:
         v = v / np.linalg.norm(v)
 

--- a/src/seemps/operators/quadratic.py
+++ b/src/seemps/operators/quadratic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
 
-
 from .mpo import MPO
 from ..typing import Tensor3, Tensor4
 from ..state import MPS, CanonicalMPS, Strategy
@@ -34,7 +33,12 @@ class QuadraticForm:
     def __init__(
         self, O: MPO, state: CanonicalMPS, start: int = 0, ket: MPS | None = None
     ):
+        # Initialize self.O, self.state and self.ket by reference
         self.O = O
+        if not isinstance(state, CanonicalMPS):
+            raise Exception("QuadraticForm: state must be a CanonicalMPS")
+        if state.center not in [start, start + 1]:
+            raise Exception(f"QuadraticForm: state must be centered at start={start} or {start+1}")
         self.state = state
         self.ket = ket if ket is not None else state
         self.size = size = state.size

--- a/src/seemps/operators/quadratic.py
+++ b/src/seemps/operators/quadratic.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.sparse.linalg import LinearOperator
+
+
+from .mpo import MPO
+from ..typing import Tensor3, Tensor4
+from ..state import MPS, CanonicalMPS, Strategy
+from ..cython import _contract_last_and_first
+from ..state.environments import (
+    MPOEnvironment,
+    begin_mpo_environment,
+    update_left_mpo_environment,
+    update_right_mpo_environment,
+)
+
+
+def _make_operator(shape, dtype, matvec, rmatvec, trace):
+    op = LinearOperator(shape=shape, dtype=dtype, matvec=matvec, rmatvec=rmatvec)
+    op.trace = trace  # type: ignore[attr-defined]
+    return op
+
+
+class QuadraticForm:
+    O: MPO
+    state: CanonicalMPS
+    ket: MPS
+    size: int
+    left_env: list[MPOEnvironment]
+    right_env: list[MPOEnvironment]
+    site: int
+
+    def __init__(
+        self, O: MPO, state: CanonicalMPS, start: int = 0, ket: MPS | None = None
+    ):
+        self.O = O
+        self.state = state
+        self.ket = ket if ket is not None else state
+        self.size = size = state.size
+        if size != O.size:
+            raise Exception("QuadraticForm: MPO and MPS do not have the same size")
+        if any(Op.shape[1] != A.shape[1] for Op, A in zip(O, state)):
+            raise Exception("QuadraticForm: MPO and MPS dimensions do not match")
+
+        left_env: list[MPOEnvironment] = [begin_mpo_environment()] * size
+        right_env: list[MPOEnvironment] = left_env.copy()
+
+        # Build right environments
+        env = right_env[-1]
+        for i in range(size - 1, start, -1):
+            right_env[i - 1] = env = update_right_mpo_environment(
+                env, state[i], O[i], self.ket[i]
+            )
+
+        # Build left environments
+        env = left_env[0]
+        for i in range(0, start):
+            left_env[i + 1] = env = update_left_mpo_environment(
+                env, state[i], O[i], self.ket[i]
+            )
+
+        self.left_env = left_env
+        self.right_env = right_env
+        self.site = start
+
+    # Move optimization center and update environments
+    def move_right(self, i: int):
+        j = self.site
+        self.left_env[i] = update_left_mpo_environment(
+            self.left_env[j], self.state[j], self.O[j], self.ket[j]
+        )
+        self.site = i
+
+    def move_left(self, i: int):
+        j = self.site
+        self.right_env[i] = update_right_mpo_environment(
+            self.right_env[j], self.state[j], self.O[j], self.ket[j]
+        )
+        self.site = i
+
+    # Effective 0/1/2-site blocks
+    def zero_site_block(self, i: int):
+        return self.left_env[i], self.right_env[i - 1]
+
+    def one_site_block(self, i: int):
+        return self.left_env[i], self.O[i], self.right_env[i]
+
+    def two_site_block(self, i: int):
+        H12 = _contract_last_and_first(self.O[i], self.O[i + 1])
+        return self.left_env[i], H12, self.right_env[i + 1]
+
+    # Effective 0-site operator
+    def zero_site_operator(self, i: int) -> LinearOperator:
+        L, R = self.zero_site_block(i)
+        b = L.shape[2]
+        f = R.shape[2]
+        v_shape = (b, f)
+        n = b * f
+        dtype = np.result_type(L.dtype, R.dtype)
+
+        def _matvec(v: np.ndarray, _L=L, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L, axes=(0, 2))
+            return np.tensordot(aux, _R, axes=([0, 2], [2, 1])).reshape(-1)
+
+        def _rmatvec(v: np.ndarray, _L=L, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L.conj(), axes=(0, 0))
+            return np.tensordot(aux, _R.conj(), axes=([0, 1], [0, 1])).reshape(-1)
+
+        def _trace(_L=L, _R=R) -> complex:
+            l_c = np.trace(_L, axis1=0, axis2=2)
+            r_e = np.trace(_R, axis1=0, axis2=2)
+            return np.vdot(l_c, r_e)
+
+        return _make_operator((n, n), dtype, _matvec, _rmatvec, _trace)
+
+    # Effective 1-site operator
+    def one_site_operator(self, i: int) -> LinearOperator:
+        L, H, R = self.one_site_block(i)
+        b = L.shape[2]
+        s = H.shape[2]
+        f = R.shape[2]
+        v_shape = (b, s, f)
+        n = b * s * f
+        dtype = np.result_type(L.dtype, R.dtype, H.dtype)
+
+        def _matvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L, axes=(0, 2))
+            aux = np.tensordot(aux, _H, axes=([0, 3], [2, 0]))
+            return np.tensordot(aux, _R, axes=([0, 3], [2, 1])).reshape(-1)
+
+        def _rmatvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L.conj(), axes=(0, 0))
+            aux = np.tensordot(aux, _H.conj(), axes=([0, 2], [1, 0]))
+            return np.tensordot(aux, _R.conj(), axes=([0, 3], [0, 1])).reshape(-1)
+
+        def _trace(_L=L, _H=H, _R=R) -> complex:
+            l_c = np.trace(_L, axis1=0, axis2=2)
+            w_ce = np.trace(_H, axis1=1, axis2=2)
+            r_e = np.trace(_R, axis1=0, axis2=2)
+            return np.dot(l_c, np.dot(w_ce, r_e))
+
+        return _make_operator((n, n), dtype, _matvec, _rmatvec, _trace)
+
+    # Effective 2-site operator
+    def two_site_operator(self, i: int) -> LinearOperator:
+        L, H, R = self.two_site_block(i)
+        k = H.shape[2]
+        l = H.shape[4]
+        b = L.shape[2]
+        f = R.shape[2]
+        v_shape = (b, k, l, f)
+        n = b * k * l * f
+        dtype = np.result_type(L.dtype, R.dtype, H.dtype)
+
+        def _matvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L, ((0,), (2,)))
+            aux = np.tensordot(aux, _H, ((0, 1, 4), (2, 4, 0)))
+            return np.tensordot(aux, _R, ((0, 4), (2, 1))).reshape(-1)
+
+        def _rmatvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+            v = v.reshape(_vs)
+            aux = np.tensordot(v, _L.conj(), axes=(0, 0))
+            aux = np.tensordot(aux, _H.conj(), axes=([3, 0, 1], [0, 1, 3]))
+            return np.tensordot(aux, _R.conj(), axes=([0, 4], [0, 1])).reshape(-1)
+
+        def _trace(_L=L, _H=H, _R=R) -> complex:
+            l_c = np.trace(_L, axis1=0, axis2=2)
+            tmp = np.trace(_H, axis1=1, axis2=2)
+            w_ce = np.trace(tmp, axis1=1, axis2=2)
+            r_e = np.trace(_R, axis1=0, axis2=2)
+            return np.dot(l_c, np.dot(w_ce, r_e))
+
+        return _make_operator((n, n), dtype, _matvec, _rmatvec, _trace)
+
+    def gradient_1site(self) -> Tensor3:
+        """Return the gradient tensor d<state|O|ket>/dstate* at the current
+        center site."""
+        c = self.site
+        L = self.left_env[c]  # (a, c, b)
+        Oc = self.O[c]  # (c, j, i, e)
+        A = self.ket[c]  # (b, i, f)
+        R = self.right_env[c]  # (d, e, f)
+
+        a, c_, b = L.shape
+        _, j, i, e = Oc.shape
+        _, _, f = A.shape
+        d = R.shape[0]
+
+        # L(a,c,b) * Oc(c,j,i,e) -> aux(a,b,j,i,e)
+        aux = np.matmul(
+            L.transpose(0, 2, 1).reshape(a * b, c_),
+            Oc.reshape(c_, j * i * e),
+        ).reshape(a, b, j, i, e)
+
+        # aux(a,b,j,i,e) * A(b,i,f) -> aux(a,j,e,f)
+        aux = np.matmul(
+            aux.transpose(0, 2, 4, 1, 3).reshape(a * j * e, b * i),
+            A.reshape(b * i, f),
+        ).reshape(a, j, e, f)
+
+        # aux(a,j,e,f) * R(d,e,f) -> result(a,j,d)
+        result = np.matmul(
+            aux.reshape(a * j, e * f),
+            R.reshape(d, e * f).T,
+        ).reshape(a, j, d)
+
+        return result
+
+    def gradient_2site(self, direction: int) -> Tensor4:
+        """Return the gradient tensor for two sites.
+
+        Parameters
+        ----------
+        direction : {+1, -1}
+            If positive, acts on (site, site+1).
+            Otherwise on (site-1, site).
+        """
+        if direction > 0:
+            i = self.site
+            j = i + 1
+        else:
+            j = self.site
+            i = j - 1
+
+        L = self.left_env[i]  # (a, c, b)
+        Oi = self.O[i]  # (c, j, i, e)
+        A = self.ket[i]  # (b, i, f)
+        Oj = self.O[j]  # (e, l, k, d)
+        B = self.ket[j]  # (f, k, g)
+        R = self.right_env[j]  # (h, d, g)
+        a, c_, b = L.shape
+        _, j_, i_, e = Oi.shape
+        _, _, f = A.shape
+        _, l_, k_, d_ = Oj.shape
+        _, _, g = B.shape
+        h = R.shape[0]
+        # L(a,c,b) * Oi(c,j,i,e) -> aux(a,b,j,i,e)
+        aux = np.matmul(
+            L.transpose(0, 2, 1).reshape(a * b, c_),
+            Oi.reshape(c_, j_ * i_ * e),
+        ).reshape(a, b, j_, i_, e)
+        # aux(a,b,j,i,e) * A(b,i,f) -> aux(a,j,e,f)
+        aux = np.matmul(
+            aux.transpose(0, 2, 4, 1, 3).reshape(a * j_ * e, b * i_),
+            A.reshape(b * i_, f),
+        ).reshape(a, j_, e, f)
+        # Oj(e,l,k,d) * B(f,k,g) -> aux2(e,l,d,f,g)
+        aux2 = np.matmul(
+            Oj.transpose(0, 1, 3, 2).reshape(e * l_ * d_, k_),
+            B.transpose(1, 0, 2).reshape(k_, f * g),
+        ).reshape(e, l_, d_, f, g)
+        # aux2(e,l,d,f,g) * R(h,d,g) -> aux2(e,l,f,h)
+        aux2 = np.matmul(
+            aux2.transpose(0, 1, 3, 2, 4).reshape(e * l_ * f, d_ * g),
+            R.reshape(h, d_ * g).T,
+        ).reshape(e, l_, f, h)
+        # aux(a,j,e,f) * aux2(e,l,f,h) -> result(a,j,l,h)
+        return np.matmul(
+            aux.transpose(0, 1, 3, 2).reshape(a * j_, f * e),
+            aux2.transpose(2, 0, 1, 3).reshape(f * e, l_ * h),
+        ).reshape(a, j_, l_, h)
+
+    def ket_2site(self, i: int):
+        A = self.ket[i]
+        B = self.ket[i + 1]
+        return _contract_last_and_first(A, B)
+
+    # Update sites and the corresponding environment
+    def update_2site_right(self, AB: Tensor4, i: int, strategy: Strategy) -> None:
+        self.state.update_2site_right(AB, i, strategy)
+        if i < self.size - 2:
+            self.site = j = i + 1
+            self.left_env[j] = update_left_mpo_environment(
+                self.left_env[i], self.state[i], self.O[i], self.ket[i]
+            )
+
+    def update_2site_left(self, AB: Tensor4, i: int, strategy: Strategy) -> None:
+        self.state.update_2site_left(AB, i, strategy)
+        if i > 0:
+            j = i + 1
+            self.right_env[i] = update_right_mpo_environment(
+                self.right_env[j], self.state[j], self.O[j], self.ket[j]
+            )
+            self.site = i - 1

--- a/src/seemps/operators/quadratic.py
+++ b/src/seemps/operators/quadratic.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.sparse.linalg import LinearOperator
 
 from .mpo import MPO
-from ..typing import Tensor3, Tensor4
+from ..typing import Tensor3, Tensor4, Weight
 from ..state import MPS, CanonicalMPS, Strategy
 from ..cython import _contract_last_and_first
 from ..state.environments import (
@@ -21,7 +21,7 @@ def _make_operator(
     dtype: Any,
     matvec: Callable[[np.ndarray], np.ndarray],
     rmatvec: Callable[[np.ndarray], np.ndarray],
-    trace: Callable[[], complex],
+    trace: Callable[[], Weight],
 ) -> LinearOperator:
     op = LinearOperator(shape=shape, dtype=dtype, matvec=matvec, rmatvec=rmatvec)
     setattr(op, "trace", trace)
@@ -132,7 +132,7 @@ class QuadraticForm:
             aux = np.tensordot(v, _L.conj(), axes=(0, 0))
             return np.tensordot(aux, _R.conj(), axes=([0, 1], [0, 1])).reshape(-1)
 
-        def _trace(_L: np.ndarray = L, _R: np.ndarray = R) -> complex:
+        def _trace(_L: np.ndarray = L, _R: np.ndarray = R) -> Weight:
             l_c = np.trace(_L, axis1=0, axis2=2)
             r_e = np.trace(_R, axis1=0, axis2=2)
             return np.vdot(l_c, r_e)
@@ -175,7 +175,7 @@ class QuadraticForm:
 
         def _trace(
             _L: np.ndarray = L, _H: np.ndarray = H, _R: np.ndarray = R
-        ) -> complex:
+        ) -> Weight:
             l_c = np.trace(_L, axis1=0, axis2=2)
             w_ce = np.trace(_H, axis1=1, axis2=2)
             r_e = np.trace(_R, axis1=0, axis2=2)
@@ -220,7 +220,7 @@ class QuadraticForm:
 
         def _trace(
             _L: np.ndarray = L, _H: np.ndarray = H, _R: np.ndarray = R
-        ) -> complex:
+        ) -> Weight:
             l_c = np.trace(_L, axis1=0, axis2=2)
             tmp = np.trace(_H, axis1=1, axis2=2)
             w_ce = np.trace(tmp, axis1=1, axis2=2)

--- a/src/seemps/operators/quadratic.py
+++ b/src/seemps/operators/quadratic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Callable, Any
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
 
@@ -15,9 +16,15 @@ from ..state.environments import (
 )
 
 
-def _make_operator(shape, dtype, matvec, rmatvec, trace):
+def _make_operator(
+    shape: tuple[int, int],
+    dtype: Any,
+    matvec: Callable[[np.ndarray], np.ndarray],
+    rmatvec: Callable[[np.ndarray], np.ndarray],
+    trace: Callable[[], complex],
+) -> LinearOperator:
     op = LinearOperator(shape=shape, dtype=dtype, matvec=matvec, rmatvec=rmatvec)
-    op.trace = trace  # type: ignore[attr-defined]
+    setattr(op, "trace", trace)
     return op
 
 
@@ -38,7 +45,9 @@ class QuadraticForm:
         if not isinstance(state, CanonicalMPS):
             raise Exception("QuadraticForm: state must be a CanonicalMPS")
         if state.center not in [start, start + 1]:
-            raise Exception(f"QuadraticForm: state must be centered at start={start} or {start+1}")
+            raise Exception(
+                f"QuadraticForm: state must be centered at start={start} or {start + 1}"
+            )
         self.state = state
         self.ket = ket if ket is not None else state
         self.size = size = state.size
@@ -103,17 +112,27 @@ class QuadraticForm:
         n = b * f
         dtype = np.result_type(L.dtype, R.dtype)
 
-        def _matvec(v: np.ndarray, _L=L, _R=R, _vs=v_shape) -> np.ndarray:
+        def _matvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L, axes=(0, 2))
             return np.tensordot(aux, _R, axes=([0, 2], [2, 1])).reshape(-1)
 
-        def _rmatvec(v: np.ndarray, _L=L, _R=R, _vs=v_shape) -> np.ndarray:
+        def _rmatvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L.conj(), axes=(0, 0))
             return np.tensordot(aux, _R.conj(), axes=([0, 1], [0, 1])).reshape(-1)
 
-        def _trace(_L=L, _R=R) -> complex:
+        def _trace(_L: np.ndarray = L, _R: np.ndarray = R) -> complex:
             l_c = np.trace(_L, axis1=0, axis2=2)
             r_e = np.trace(_R, axis1=0, axis2=2)
             return np.vdot(l_c, r_e)
@@ -130,19 +149,33 @@ class QuadraticForm:
         n = b * s * f
         dtype = np.result_type(L.dtype, R.dtype, H.dtype)
 
-        def _matvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+        def _matvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _H: np.ndarray = H,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L, axes=(0, 2))
             aux = np.tensordot(aux, _H, axes=([0, 3], [2, 0]))
             return np.tensordot(aux, _R, axes=([0, 3], [2, 1])).reshape(-1)
 
-        def _rmatvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+        def _rmatvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _H: np.ndarray = H,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L.conj(), axes=(0, 0))
             aux = np.tensordot(aux, _H.conj(), axes=([0, 2], [1, 0]))
             return np.tensordot(aux, _R.conj(), axes=([0, 3], [0, 1])).reshape(-1)
 
-        def _trace(_L=L, _H=H, _R=R) -> complex:
+        def _trace(
+            _L: np.ndarray = L, _H: np.ndarray = H, _R: np.ndarray = R
+        ) -> complex:
             l_c = np.trace(_L, axis1=0, axis2=2)
             w_ce = np.trace(_H, axis1=1, axis2=2)
             r_e = np.trace(_R, axis1=0, axis2=2)
@@ -161,19 +194,33 @@ class QuadraticForm:
         n = b * k * l * f
         dtype = np.result_type(L.dtype, R.dtype, H.dtype)
 
-        def _matvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+        def _matvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _H: np.ndarray = H,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L, ((0,), (2,)))
             aux = np.tensordot(aux, _H, ((0, 1, 4), (2, 4, 0)))
             return np.tensordot(aux, _R, ((0, 4), (2, 1))).reshape(-1)
 
-        def _rmatvec(v: np.ndarray, _L=L, _H=H, _R=R, _vs=v_shape) -> np.ndarray:
+        def _rmatvec(
+            v: np.ndarray,
+            _L: np.ndarray = L,
+            _H: np.ndarray = H,
+            _R: np.ndarray = R,
+            _vs: tuple[int, ...] = v_shape,
+        ) -> np.ndarray:
             v = v.reshape(_vs)
             aux = np.tensordot(v, _L.conj(), axes=(0, 0))
             aux = np.tensordot(aux, _H.conj(), axes=([3, 0, 1], [0, 1, 3]))
             return np.tensordot(aux, _R.conj(), axes=([0, 4], [0, 1])).reshape(-1)
 
-        def _trace(_L=L, _H=H, _R=R) -> complex:
+        def _trace(
+            _L: np.ndarray = L, _H: np.ndarray = H, _R: np.ndarray = R
+        ) -> complex:
             l_c = np.trace(_L, axis1=0, axis2=2)
             tmp = np.trace(_H, axis1=1, axis2=2)
             w_ce = np.trace(tmp, axis1=1, axis2=2)

--- a/src/seemps/operators/quadratic.py
+++ b/src/seemps/operators/quadratic.py
@@ -48,7 +48,7 @@ class QuadraticForm:
 
         # Build right environments
         env = right_env[-1]
-        for i in range(size - 1, start, -1):
+        for i in range(size - 1, max(0, start - 1), -1):
             right_env[i - 1] = env = update_right_mpo_environment(
                 env, state[i], O[i], self.ket[i]
             )

--- a/src/seemps/optimization/dmrg.py
+++ b/src/seemps/optimization/dmrg.py
@@ -90,12 +90,14 @@ def dmrg(
     logger(f"DMRG initiated with maxiter={maxiter}, relative tolerance={tol}")
     if not isinstance(guess, CanonicalMPS):
         guess = CanonicalMPS(guess, center=0)
-    if guess.center == 0:
+    if guess.center <= guess.size // 2:
         direction = +1
+        guess = CanonicalMPS(guess, center=0)
         QF = QuadraticForm(H, guess, start=0)
     else:
         direction = -1
-        QF = QuadraticForm(H, guess, start=H.size - 2)
+        guess = CanonicalMPS(guess, center=-1)
+        QF = QuadraticForm(H, guess, start=guess.size - 2)
     energy = H.expectation(QF.state).real
     variance = abs(H.apply(QF.state).norm_squared() - energy * energy)
     results = OptimizeResults(

--- a/src/seemps/optimization/dmrg.py
+++ b/src/seemps/optimization/dmrg.py
@@ -6,216 +6,24 @@ from ..tools import make_logger
 from ..typing import Tensor4
 from ..state import DEFAULT_STRATEGY, MPS, CanonicalMPS, Strategy, random_mps
 from ..cython import _contract_last_and_first
-from ..state.environments import (
-    MPOEnvironment,
-    begin_mpo_environment,
-    update_left_mpo_environment,
-    update_right_mpo_environment,
-)
 from ..operators import MPO
+from ..operators.quadratic import QuadraticForm
 from ..hamiltonians import NNHamiltonian
 from .descent import OptimizeResults
-from numpy import tensordot
 
 
-class DMRGMatrixOperator(scipy.sparse.linalg.LinearOperator):
-    L: np.ndarray
-    R: np.ndarray
-    H12: np.ndarray
-    v_shape: tuple[int, int, int, int]
-
-    def __init__(self, L: np.ndarray, H12: np.ndarray, R: np.ndarray):
-        _, _, k, _, l, _ = H12.shape
-        _, _, b = L.shape
-        _, _, f = R.shape
-        self.L = L
-        self.R = R
-        self.H12 = H12
-        self.v_shape = (b, k, l, f)
-        # We have to ignore typing because scipy-stubs has errors in
-        # the declaration of LinearOperator
-        super().__init__(
-            shape=(b * k * l * f, b * k * l * f),  # type: ignore # pyright: ignore[reportCallIssue]
-            dtype=type(L[0, 0, 0] * R[0, 0, 0] * H12[0, 0, 0, 0, 0, 0]),  # type: ignore # pyright: ignore[reportCallIssue]
-        )
-
-    def _matvec(self, v: np.ndarray) -> np.ndarray:
-        """This sequence comes from
-        a = opt_einsum.contract_path(
-            "acb,cikjld,edf,bklf->aije",
-            ArrayShaped((100, 120, 100)),
-            ArrayShaped((120, 2, 2, 2, 2, 120)),
-            ArrayShaped((100, 120, 100)),
-            ArrayShaped((100, 2, 2, 100)),
-        )
-        print(a)
-
-                    Naive scaling:  10
-            Optimized scaling:  8
-            Naive FLOP count:  9.216e+13
-        Optimized FLOP count:  6.528e+9
-        Theoretical speedup:  1.412e+4
-        Largest intermediate:  4.800e+6 elements
-        --------------------------------------------------------------------------------
-        scaling        BLAS                current                             remaining
-        --------------------------------------------------------------------------------
-        6           GEMM        bklf,acb->klfac                cikjld,edf,klfac->aije
-        8           TDOT    klfac,cikjld->faijd                       edf,faijd->aije
-        6           TDOT        faijd,edf->aije                            aije->aije)
-        ([(0, 3), (0, 2), (0, 1)],   Complete contraction:  abc,cijkld,def,bklf->aije
-        """
-        v = v.reshape(self.v_shape)
-        aux = tensordot(v, self.L, ((0,), (2,)))
-        aux = tensordot(aux, self.H12, ((0, 1, 4), (2, 4, 0)))
-        return tensordot(aux, self.R, ((0, 4), (2, 1))).reshape(-1)
-
-    def _rmatvec(self, v: np.ndarray) -> np.ndarray:
-        a = self.L.shape[0]
-        i = self.H12.shape[1]
-        j = self.H12.shape[3]
-        e = self.R.shape[0]
-
-        v = v.reshape(a, i, j, e)
-        aux = tensordot(v, self.L.conj(), axes=(0, 0))
-        aux = tensordot(aux, self.H12.conj(), axes=([3, 0, 1], [0, 1, 3]))
-        aux = tensordot(aux, self.R.conj(), axes=([0, 4], [0, 1]))
-
-        return aux.reshape(-1)
-
-    def trace(self) -> complex:
-        l_c = np.trace(self.L, axis1=0, axis2=2)
-        tmp = np.trace(self.H12, axis1=1, axis2=2)
-        w_ce = np.trace(tmp, axis1=1, axis2=2)
-        r_e = np.trace(self.R, axis1=0, axis2=2)
-        return np.dot(l_c, np.dot(w_ce, r_e))
-
-
-class OneSiteDMRGOperator(scipy.sparse.linalg.LinearOperator):
-    L: np.ndarray
-    H_mpo: np.ndarray
-    R: np.ndarray
-    v_shape: tuple[int, int, int]
-
-    def __init__(self, L: np.ndarray, H: np.ndarray, R: np.ndarray):
-        self.L = L
-        self.H_mpo = H
-        self.R = R
-        _, _, b = L.shape
-        _, _, f = R.shape
-        _, _, k, _ = H.shape
-        self.v_shape = (b, k, f)
-
-        super().__init__(dtype=L.dtype, shape=(b * k * f, b * k * f))  # type: ignore[call-arg] # pyright: ignore[reportCallIssue]
-
-    def _matvec(self, v: np.ndarray) -> np.ndarray:
-        v = v.reshape(self.v_shape)
-
-        aux = tensordot(v, self.L, axes=(0, 2))
-        aux = tensordot(aux, self.H_mpo, axes=([0, 3], [2, 0]))
-        aux = tensordot(aux, self.R, axes=([0, 3], [2, 1]))
-
-        return aux.reshape(-1)
-
-    def _rmatvec(self, v: np.ndarray) -> np.ndarray:
-        a = self.L.shape[0]
-        g = self.H_mpo.shape[1]
-        d = self.R.shape[0]
-        v = v.reshape(a, g, d)
-
-        aux = tensordot(v, self.L.conj(), axes=(0, 0))
-        aux = tensordot(aux, self.H_mpo.conj(), axes=([0, 2], [1, 0]))
-        aux = tensordot(aux, self.R.conj(), axes=([0, 3], [0, 1]))
-
-        return aux.reshape(-1)
-
-    def trace(self) -> complex:
-        l_c = np.trace(self.L, axis1=0, axis2=2)
-        w_ce = np.trace(self.H_mpo, axis1=1, axis2=2)
-        r_e = np.trace(self.R, axis1=0, axis2=2)
-        return np.dot(l_c, np.dot(w_ce, r_e))
-
-
-class QuadraticForm:
-    H: MPO
-    state: CanonicalMPS
-    size: int
-    left_env: list[MPOEnvironment]
-    right_env: list[MPOEnvironment]
-    site: int
-
-    def __init__(self, H: MPO, state: CanonicalMPS, start: int = 0):
-        self.H = H
-        self.state = state
-        self.size = size = state.size
-        if size != H.size:
-            raise Exception("In QuadraticForm, MPO and MPS do not have the same size")
-        if any(O.shape[1] != A.shape[1] for O, A in zip(H, state)):
-            raise Exception(
-                "In QuadraticForm, MPO and MPS do not have matching dimensions"
-            )
-        left_env = [begin_mpo_environment()] * size
-        right_env = left_env.copy()
-        env = right_env[-1]
-        for i in range(size - 1, start, -1):
-            right_env[i - 1] = env = update_right_mpo_environment(
-                env, state[i], H[i], state[i]
-            )
-        env = left_env[0]
-        for i in range(0, start):
-            left_env[i + 1] = env = update_left_mpo_environment(
-                env, state[i], H[i], state[i]
-            )
-        self.left_env = left_env
-        self.right_env = right_env
-        self.site = start
-
-    def two_site_Hamiltonian(self, i: int) -> DMRGMatrixOperator:
-        assert i == self.site
-        return DMRGMatrixOperator(  # pyright: ignore[reportCallIssue]
-            self.left_env[i],  # type: ignore # pyright: ignore[reportArgumentType]
-            _contract_last_and_first(self.H[i], self.H[i + 1]),  # type: ignore # pyright: ignore[reportArgumentType]
-            self.right_env[i + 1],  # type: ignore # pyright: ignore[reportArgumentType]
-        )
-
-    def diagonalize(self, i: int, tol: float) -> tuple[float, Tensor4]:
-        Op = self.two_site_Hamiltonian(i)
-        v = _contract_last_and_first(self.state[i], self.state[i + 1])
-        v /= np.linalg.norm(v.reshape(-1))
-        eval, evec = scipy.sparse.linalg.eigsh(
-            Op, 1, which="SA", v0=v.reshape(-1), tol=tol
-        )
-        return eval[0], evec.reshape(v.shape)
-
-    def solve(
-        self,
-        i: int,
-        b: Tensor4,
-        atol: float = 0,
-        rtol: float = 1e-5,
-        solver: Callable = scipy.sparse.linalg.bicgstab,
-    ) -> tuple[Tensor4, int, float]:
-        Op = self.two_site_Hamiltonian(i)
-        v = _contract_last_and_first(self.state[i], self.state[i + 1])
-        x, info = solver(Op, b.reshape(-1), v.reshape(-1), atol=atol, rtol=rtol)
-        res = np.linalg.norm(Op @ x - b.reshape(-1))
-        return x.reshape(v.shape), info, float(res)
-
-    def update_2site_right(self, AB: Tensor4, i: int, strategy: Strategy) -> None:
-        self.state.update_2site_right(AB, i, strategy)
-        if i < self.size - 2:
-            self.site = j = i + 1
-            self.left_env[j] = update_left_mpo_environment(
-                self.left_env[i], self.state[i], self.H[i], self.state[i]
-            )
-
-    def update_2site_left(self, AB: Tensor4, i: int, strategy: Strategy) -> None:
-        self.state.update_2site_left(AB, i, strategy)
-        if i > 0:
-            j = i + 1
-            self.right_env[i] = update_right_mpo_environment(
-                self.right_env[j], self.state[j], self.H[j], self.state[j]
-            )
-            self.site = i - 1
+def _diagonalize_two_site(
+    QF: QuadraticForm, i: int, tol: float
+) -> tuple[float, Tensor4]:
+    Op = QF.two_site_operator(i)
+    v = _contract_last_and_first(QF.state[i], QF.state[i + 1])
+    v_shape = v.shape
+    v = v.reshape(-1)
+    v /= np.linalg.norm(v)
+    eval, evec = scipy.sparse.linalg.eigsh(
+        Op, 1, which="SA", v0=v, tol=tol
+    )
+    return eval[0], evec.reshape(v_shape)
 
 
 def dmrg(
@@ -308,12 +116,12 @@ def dmrg(
     for step in range(maxiter):
         if direction > 0:
             for i in range(0, H.size - 1):
-                E, AB = QF.diagonalize(i, tol=tol_eigs)
+                E, AB = _diagonalize_two_site(QF, i, tol_eigs)
                 QF.update_2site_right(AB, i, strategy)
                 logger(f"-> site={i}, eigenvalue={E}")
         else:
             for i in range(H.size - 2, -1, -1):
-                E, AB = QF.diagonalize(i, tol=tol_eigs)
+                E, AB = _diagonalize_two_site(QF, i, tol_eigs)
                 QF.update_2site_left(AB, i, strategy)
                 logger(f"<- site={i}, eigenvalue={E}")
 

--- a/src/seemps/solve/dmrg.py
+++ b/src/seemps/solve/dmrg.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
+from typing import Callable
 import numpy as np
 import scipy.sparse.linalg
 from ..tools import make_logger
+from ..typing import Tensor4
 from ..state import DEFAULT_STRATEGY, MPS, CanonicalMPS, Strategy
 from ..state.simplification import AntilinearForm
+from ..cython import _contract_last_and_first
 from ..operators import MPO
-from ..optimization.dmrg import QuadraticForm
+from ..operators.quadratic import QuadraticForm
+
+
+def _solve_two_site(
+    QF: QuadraticForm,
+    i: int,
+    b: Tensor4,
+    atol: float,
+    rtol: float,
+    solver: Callable,
+) -> tuple[Tensor4, int, float]:
+    Op = QF.two_site_operator(i)
+    v = _contract_last_and_first(QF.state[i], QF.state[i + 1])
+    x, info = solver(Op, b.reshape(-1), v.reshape(-1), atol=atol, rtol=rtol)
+    res = np.linalg.norm(Op @ x - b.reshape(-1))
+    return x.reshape(v.shape), info, float(res)
 
 
 def dmrg_solve(
@@ -87,8 +105,8 @@ def dmrg_solve(
         if step:
             if direction > 0:
                 for i in range(0, A.size - 1):
-                    AB, info, local_residual = QF.solve(
-                        i, LF.tensor2site(+1), atol, rtol, solver=solver
+                    AB, info, local_residual = _solve_two_site(
+                        QF, i, LF.tensor2site(+1), atol, rtol, solver
                     )
                     QF.update_2site_right(AB, i, strategy)
                     LF.update_right()
@@ -99,8 +117,8 @@ def dmrg_solve(
                         message = "Local optimization with gmres() did not converge"
             else:
                 for i in range(A.size - 2, -1, -1):
-                    AB, info, local_residual = QF.solve(
-                        i, LF.tensor2site(-1), atol, rtol, solver=solver
+                    AB, info, local_residual = _solve_two_site(
+                        QF, i, LF.tensor2site(-1), atol, rtol, solver
                     )
                     QF.update_2site_left(AB, i, strategy)
                     LF.update_left()

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -27,20 +27,3 @@ class TestTwoSiteEvolutionFold(SeeMPSTestCase):
         )
         fast_contraction = seemps.cython._contract_nrjl_ijk_klm(U, A, B)
         self.assertSimilar(exact_contraction, fast_contraction)
-
-
-class TestDMRGHamiltonianContraction(SeeMPSTestCase):
-    def test_contract_A_B(self):
-        from seemps.optimization.dmrg import DMRGMatrixOperator
-
-        L = self.rng.normal(size=(10, 5, 10))
-        R = self.rng.normal(size=(13, 6, 13))
-        H12 = self.rng.normal(size=(5, 3, 3, 2, 2, 6))
-        v = self.rng.normal(size=(10, 3, 2, 13))
-
-        exact_contraction = np.einsum(
-            "acb,cikjld,edf,bklf->aije", L, H12, R, v
-        ).reshape(-1)
-        dmrg_contractor = DMRGMatrixOperator(L, H12, R)  # type: ignore
-        fast_contraction = dmrg_contractor(v.reshape(-1))
-        self.assertSimilar(exact_contraction, fast_contraction)

--- a/tests/test_operators/test_quadratic_form.py
+++ b/tests/test_operators/test_quadratic_form.py
@@ -1,64 +1,361 @@
 import numpy as np
-from seemps.optimization.dmrg import QuadraticForm
+from seemps.operators.quadratic import QuadraticForm
 from seemps.hamiltonians import ConstantTIHamiltonian
 from seemps.cython import _contract_last_and_first
-from seemps.state import CanonicalMPS
+from seemps.state import CanonicalMPS, NO_TRUNCATION
 from seemps.operators import MPO
-from seemps.typing import DenseOperator
 from ..tools import SeeMPSTestCase
 
 
 class TestQuadraticForm(SeeMPSTestCase):
-    Sz: DenseOperator = np.diag([1, -1])
-    Sx: DenseOperator = np.array([[0, 1], [1, 0]])
-
     def setUp(self) -> None:
         return super().setUp()
 
-    def _make_H(self, size: int) -> ConstantTIHamiltonian:
-        return ConstantTIHamiltonian(size=size, interaction=np.kron(self.Sz, self.Sx))
+    def _H(self, size: int) -> MPO:
+        Sz = np.diag([1, -1])
+        Sx = np.array([[0, 1], [1, 0]])
+        H = ConstantTIHamiltonian(size=size, interaction=np.kron(Sz, Sx))
+        return H.to_mpo()
 
-    def _canonical(self, size: int, D: int = 2, center: int = 0) -> CanonicalMPS:
-        return CanonicalMPS(self.random_uniform_mps(2, size, D=D), center=center)
+    def _random_canonical(
+        self, size: int, D: int = 2, center: int = 0, complex: bool = False
+    ) -> CanonicalMPS:
+        return CanonicalMPS(
+            self.random_uniform_mps(2, size, D=D, complex=complex), center=center
+        )
+
+    def _assert_adjoint_consistent(self, op):
+        n = op.shape[0]
+        rng = np.random.default_rng(42)
+        u = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+        v = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+        lhs = np.vdot(u, op.matvec(v))
+        rhs = np.vdot(op.rmatvec(u), v)
+        self.assertAlmostEqual(lhs, rhs)
+
+    def _dense_trace(self, op):
+        n = op.shape[0]
+        return sum((op @ np.eye(n)[i])[i] for i in range(n))
 
     def test_quadratic_form_checks_mpo_size(self):
         mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
-        mps = self.random_uniform_mps(2, 4)
+        mps = self._random_canonical(4)
         with self.assertRaises(Exception):
             QuadraticForm(mpo, mps)  # type: ignore
 
     def test_quadratic_form_checks_mpo_dimensions(self):
         mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
-        mps = self.random_uniform_mps(3, 3)
+        mps = CanonicalMPS(self.random_uniform_mps(3, 3), center=0)
         with self.assertRaises(Exception):
             QuadraticForm(mpo, mps)  # type: ignore
 
-    def test_quadratic_form_two_sites(self):
-        H = self._make_H(2)
-        Hmpo = H.to_mpo()
-        state = CanonicalMPS(self.random_uniform_mps(2, 2, D=2), center=0)
+    def test_quadratic_form_checks_state_is_canonical_and_centered(self):
+        H = self._H(3)
+        state = self.random_uniform_mps(2, 3, D=2)
+        with self.assertRaises(Exception):
+            QuadraticForm(H, state, start=1)
+
+        state_canonical = CanonicalMPS(state, center=0)
+        with self.assertRaises(Exception):
+            QuadraticForm(H, state_canonical, start=1)
+
+    # Blocks shapes
+    def test_blocks_shapes(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=0)
+        Q = QuadraticForm(H, state, start=0)
+        Q.move_right(1)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+
+        L, R = Q.zero_site_block(1)
+        self.assertEqual(L.ndim, 3)
+        self.assertEqual(R.ndim, 3)
+
+        L, O, R = Q.one_site_block(1)
+        self.assertEqual(L.ndim, 3)
+        self.assertEqual(O.ndim, 4)
+        self.assertEqual(R.ndim, 3)
+
+        L, O12, R = Q.two_site_block(1)
+        self.assertEqual(L.ndim, 3)
+        self.assertEqual(O12.ndim, 6)
+        self.assertEqual(R.ndim, 3)
+
+    # Environment updates (move_right / move_left)
+    def test_move_right_preserves_expectation(self):
+        Hmpo = self._H(4)
+        state = self._random_canonical(4, center=0)
         Q = QuadraticForm(Hmpo, state, start=0)
+        Q.move_right(1)
+        AB = Q.ket_2site(1)
+        HopAB = Q.two_site_operator(1) @ AB.reshape(-1)
+        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))
+
+    def test_move_left_preserves_expectation(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=3)
+        Q = QuadraticForm(H, state, start=3)
+        Q.move_left(2)
+        AB = Q.ket_2site(1)
+        HopAB = Q.two_site_operator(1) @ AB.reshape(-1)
+        self.assertAlmostEqual(np.vdot(AB, HopAB), H.expectation(state))
+
+    def test_gradient_shapes(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1)
+        Q = QuadraticForm(H, state, start=1)
+
+        grad1 = Q.gradient_1site()
+        self.assertEqual(grad1.shape, state[1].shape)
+
+        grad2_right = Q.gradient_2site(1)
+        self.assertEqual(grad2_right.shape, Q.ket_2site(1).shape)
+
+        grad2_left = Q.gradient_2site(-1)
+        self.assertEqual(grad2_left.shape, Q.ket_2site(0).shape)
+
+    # Left/right updates
+    def test_update_2site_right(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        AB = Q.ket_2site(1)
+        expected_energy = H.expectation(state)
+
+        Q.update_2site_right(AB, 1, NO_TRUNCATION)
+        self.assertEqual(Q.site, 2)
+        self.assertAlmostEqual(expected_energy, H.expectation(Q.state))
+
+    def test_update_2site_left(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=2)
+        Q = QuadraticForm(H, state, start=2)
+        AB = Q.ket_2site(1)
+        expected_energy = H.expectation(state)
+
+        Q.update_2site_left(AB, 1, NO_TRUNCATION)
+        self.assertEqual(Q.site, 0)
+        self.assertAlmostEqual(expected_energy, H.expectation(Q.state))
+
+    def test_update_2site_right_boundary(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=2)
+        Q = QuadraticForm(H, state, start=2)
+        AB = Q.ket_2site(2)
+        Q.update_2site_right(AB, 2, NO_TRUNCATION)
+        self.assertEqual(Q.site, 2)
+
+    def test_update_2site_left_boundary(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=0)
+        Q = QuadraticForm(H, state, start=0)
+        AB = Q.ket_2site(0)
+        Q.update_2site_left(AB, 0, NO_TRUNCATION)
+        self.assertEqual(Q.site, 0)
+
+    # Ket different from bra
+    def test_quadratic_form_with_separate_ket(self):
+        H = self._H(2)
+        state = self._random_canonical(2, center=0)
+        ket = self._random_canonical(2, center=0)
+        Q = QuadraticForm(H, state, start=0, ket=ket)
+        AB_bra = _contract_last_and_first(Q.state[0], Q.state[1])
+        AB_ket = Q.ket_2site(0)
+        HopAB = Q.two_site_operator(0) @ AB_ket.reshape(-1)
+        expected = H.expectation(state, ket)
+        self.assertAlmostEqual(np.vdot(AB_bra, HopAB), expected)
+
+    # Zero-site operator
+    def test_zero_site_operator_shape_and_matvec(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=0)
+        Q = QuadraticForm(H, state, start=0)
+        Q.move_right(1)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        op = Q.zero_site_operator(1)
+        n = op.shape[0]
+        v = np.random.randn(n)
+        self.assertEqual((op @ v).shape, (n,))
+
+    def test_zero_site_operator_trace(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=0)
+        Q = QuadraticForm(H, state, start=0)
+        Q.move_right(1)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        op = Q.zero_site_operator(1)
+        self.assertAlmostEqual(op.trace(), self._dense_trace(op))
+
+    def test_zero_site_operator_matvec(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=0)
+        Q = QuadraticForm(H, state, start=0)
+        Q.move_right(1)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        L, R = Q.zero_site_block(1)
+        op = Q.zero_site_operator(1)
+
+        b, f = L.shape[2], R.shape[2]
+        v = np.random.randn(b, f)
+
+        result_fast = (op @ v.reshape(-1)).reshape(L.shape[0], R.shape[0])
+        result_exact = np.einsum("acb,bf,dcf->ad", L, v, R)
+
+        self.assertSimilar(result_fast, result_exact)
+
+    def test_zero_site_operator_adjoint(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1, complex=True)
+        Q = QuadraticForm(H, state, start=1)
+        self._assert_adjoint_consistent(Q.zero_site_operator(1))
+
+    # One-site operator
+    def test_one_site_operator_expectation(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        A = state[1]
+        HopA = Q.one_site_operator(1) @ A.reshape(-1)
+        self.assertAlmostEqual(np.vdot(A, HopA), H.expectation(state))
+
+    def test_one_site_operator_trace(self):
+        Hmpo = self._H(2)
+        state = self._random_canonical(2)
+        Q = QuadraticForm(Hmpo, state)
+        op = Q.one_site_operator(0)
+        self.assertAlmostEqual(op.trace(), self._dense_trace(op))
+
+    def test_gradient_1site_matches_operator(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        grad = Q.gradient_1site()
+        A = state[1]
+        via_op = Q.one_site_operator(1) @ A.reshape(-1)
+        self.assertSimilar(grad.reshape(-1), via_op)
+
+    def test_one_site_operator_matvec(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        L, O, R = Q.one_site_block(1)
+        op = Q.one_site_operator(1)
+
+        b, s, f = L.shape[2], O.shape[2], R.shape[2]
+        v = np.random.randn(b, s, f)
+
+        result_fast = (op @ v.reshape(-1)).reshape(L.shape[0], O.shape[1], R.shape[0])
+        result_exact = np.einsum("acb,cjie,bif,def->ajd", L, O, v, R)
+
+        self.assertSimilar(result_fast, result_exact)
+
+    def test_one_site_operator_adjoint(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1, complex=True)
+        Q = QuadraticForm(H, state, start=1)
+        self._assert_adjoint_consistent(Q.one_site_operator(1))
+
+    def test_gradient_1site(self):
+        H = self._H(3)
+        state = self._random_canonical(3, center=1, complex=True)
+        Q = QuadraticForm(H, state, start=1)
+
+        grad_fast = Q.gradient_1site()
+        L, O, R = Q.left_env[1], Q.O[1], Q.right_env[1]
+        A = Q.ket[1]
+
+        grad_exact = np.einsum("acb,cjie,bif,def->ajd", L, O, A, R)
+        self.assertSimilar(grad_fast, grad_exact)
+
+    # Two-site operator
+    def test_quadratic_form_two_sites(self):
+        H = self._H(2)
+        state = CanonicalMPS(self.random_uniform_mps(2, 2, D=2), center=0)
+        Q = QuadraticForm(H, state, start=0)
         Hop = Q.two_site_operator(0)
-        AB = _contract_last_and_first(state[0], state[1])
+        AB = Q.ket_2site(0)
         HopAB = Hop @ AB.reshape(-1)
         self.assertEqual(HopAB.shape, (AB.size,))
-        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore
+        self.assertAlmostEqual(np.vdot(AB, HopAB), H.expectation(state))  # type: ignore
         self.assertSimilar(H.to_matrix() @ AB.reshape(-1), HopAB)
 
-    def test_quadratic_form_three_sites_start_zero(self):
-        H = self._make_H(3)
-        Hmpo = H.to_mpo()
+    def test_quadratic_form_start_zero(self):
+        H = self._H(3)
         state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
-        Q = QuadraticForm(Hmpo, state, start=0)
-        AB = _contract_last_and_first(state[0], state[1])
+        Q = QuadraticForm(H, state, start=0)
+        AB = Q.ket_2site(0)
         HopAB = Q.two_site_operator(0) @ AB.reshape(-1)
-        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore
+        self.assertAlmostEqual(np.vdot(AB, HopAB), H.expectation(state))  # type: ignore
 
-    def test_quadratic_form_three_sites_start_one(self):
-        H = self._make_H(3)
-        Hmpo = H.to_mpo()
-        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
-        Q = QuadraticForm(Hmpo, state, start=1)
-        AB = _contract_last_and_first(state[1], state[2])
+    def test_quadratic_form_start_one(self):
+        H = self._H(3)
+        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=1)
+        Q = QuadraticForm(H, state, start=1)
+        AB = Q.ket_2site(1)
         HopAB = Q.two_site_operator(1) @ AB.reshape(-1)
-        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore
+        self.assertAlmostEqual(np.vdot(AB, HopAB), H.expectation(state))  # type: ignore
+
+    def test_two_site_operator_trace(self):
+        H = self._H(2)
+        state = self._random_canonical(2)
+        Q = QuadraticForm(H, state)
+        op = Q.two_site_operator(0)
+        self.assertAlmostEqual(op.trace(), self._dense_trace(op))
+
+    def test_gradient_2site_right_matches_operator(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        grad = Q.gradient_2site(direction=+1)
+        AB = Q.ket_2site(1)
+        via_op = Q.two_site_operator(1) @ AB.reshape(-1)
+        self.assertSimilar(grad.reshape(-1), via_op)
+
+    def test_gradient_2site_left_matches_operator(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=2)
+        Q = QuadraticForm(H, state, start=2)
+        grad = Q.gradient_2site(direction=-1)
+        AB = Q.ket_2site(1)
+        via_op = Q.two_site_operator(1) @ AB.reshape(-1)
+        self.assertSimilar(grad.reshape(-1), via_op)
+
+    def test_two_site_operator_matvec(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1)
+        Q = QuadraticForm(H, state, start=1)
+        L, H12, R = Q.two_site_block(1)
+        op = Q.two_site_operator(1)
+
+        b, i, k, g = L.shape[2], H12.shape[2], H12.shape[4], R.shape[2]
+        v = np.random.randn(b, i, k, g)
+
+        result_fast = (op @ v.reshape(-1)).reshape(
+            L.shape[0], H12.shape[1], H12.shape[3], R.shape[0]
+        )
+        result_exact = np.einsum("acb,cjilkd,bikg,hdg->ajlh", L, H12, v, R)
+
+        self.assertSimilar(result_fast, result_exact)
+
+    def test_two_site_operator_adjoint(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1, complex=True)
+        Q = QuadraticForm(H, state, start=1)
+        self._assert_adjoint_consistent(Q.two_site_operator(1))
+
+    def test_gradient_2site(self):
+        H = self._H(4)
+        state = self._random_canonical(4, center=1, complex=True)
+        Q = QuadraticForm(H, state, start=1)
+
+        grad_fast = Q.gradient_2site(1)
+        L, R = Q.left_env[1], Q.right_env[2]
+        O1, O2 = Q.O[1], Q.O[2]
+        A, B = Q.ket[1], Q.ket[2]
+
+        grad_exact = np.einsum("acb,cjie,bif,elkd,fkg,hdg->ajlh", L, O1, A, O2, B, R)
+        self.assertSimilar(grad_fast, grad_exact)

--- a/tests/test_operators/test_quadratic_form.py
+++ b/tests/test_operators/test_quadratic_form.py
@@ -1,0 +1,64 @@
+import numpy as np
+from seemps.optimization.dmrg import QuadraticForm
+from seemps.hamiltonians import ConstantTIHamiltonian
+from seemps.cython import _contract_last_and_first
+from seemps.state import CanonicalMPS
+from seemps.operators import MPO
+from seemps.typing import DenseOperator
+from ..tools import SeeMPSTestCase
+
+
+class TestQuadraticForm(SeeMPSTestCase):
+    Sz: DenseOperator = np.diag([1, -1])
+    Sx: DenseOperator = np.array([[0, 1], [1, 0]])
+
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def _make_H(self, size: int) -> ConstantTIHamiltonian:
+        return ConstantTIHamiltonian(size=size, interaction=np.kron(self.Sz, self.Sx))
+
+    def _canonical(self, size: int, D: int = 2, center: int = 0) -> CanonicalMPS:
+        return CanonicalMPS(self.random_uniform_mps(2, size, D=D), center=center)
+
+    def test_quadratic_form_checks_mpo_size(self):
+        mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
+        mps = self.random_uniform_mps(2, 4)
+        with self.assertRaises(Exception):
+            QuadraticForm(mpo, mps)  # type: ignore
+
+    def test_quadratic_form_checks_mpo_dimensions(self):
+        mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
+        mps = self.random_uniform_mps(3, 3)
+        with self.assertRaises(Exception):
+            QuadraticForm(mpo, mps)  # type: ignore
+
+    def test_quadratic_form_two_sites(self):
+        H = self._make_H(2)
+        Hmpo = H.to_mpo()
+        state = CanonicalMPS(self.random_uniform_mps(2, 2, D=2), center=0)
+        Q = QuadraticForm(Hmpo, state, start=0)
+        Hop = Q.two_site_operator(0)
+        AB = _contract_last_and_first(state[0], state[1])
+        HopAB = Hop @ AB.reshape(-1)
+        self.assertEqual(HopAB.shape, (AB.size,))
+        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore
+        self.assertSimilar(H.to_matrix() @ AB.reshape(-1), HopAB)
+
+    def test_quadratic_form_three_sites_start_zero(self):
+        H = self._make_H(3)
+        Hmpo = H.to_mpo()
+        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
+        Q = QuadraticForm(Hmpo, state, start=0)
+        AB = _contract_last_and_first(state[0], state[1])
+        HopAB = Q.two_site_operator(0) @ AB.reshape(-1)
+        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore
+
+    def test_quadratic_form_three_sites_start_one(self):
+        H = self._make_H(3)
+        Hmpo = H.to_mpo()
+        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
+        Q = QuadraticForm(Hmpo, state, start=1)
+        AB = _contract_last_and_first(state[1], state[2])
+        HopAB = Q.two_site_operator(1) @ AB.reshape(-1)
+        self.assertAlmostEqual(np.vdot(AB, HopAB), Hmpo.expectation(state))  # type: ignore

--- a/tests/test_optimization/test_dmrg.py
+++ b/tests/test_optimization/test_dmrg.py
@@ -1,83 +1,10 @@
 import numpy as np
 import scipy.sparse.linalg  # type: ignore
-from seemps.optimization.dmrg import QuadraticForm, dmrg
+from seemps.optimization.dmrg import dmrg
 from seemps.hamiltonians import ConstantTIHamiltonian, HeisenbergHamiltonian
-from seemps.cython import _contract_last_and_first
 from seemps.state import product_state, CanonicalMPS
-from seemps.operators import MPO
 from seemps.typing import DenseOperator
 from ..tools import SeeMPSTestCase
-
-
-class TestQuadraticForm(SeeMPSTestCase):
-    Sz: DenseOperator = np.diag([1, -1])
-    Sx: DenseOperator = np.array([[0, 1], [1, 0]])
-
-    def setUp(self) -> None:
-        return super().setUp()
-
-    def test_quadratic_form_checks_mpo_size(self):
-        mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
-        mps = self.random_uniform_mps(2, 4)
-        with self.assertRaises(Exception):
-            QuadraticForm(mpo, mps)  # type: ignore
-
-    def test_quadratic_form_checks_mpo_dimensions(self):
-        mpo = MPO([np.ones((1, 2, 2, 1))] * 3)
-        mps = self.random_uniform_mps(3, 3)
-        with self.assertRaises(Exception):
-            QuadraticForm(mpo, mps)  # type: ignore
-
-    def test_quadratic_form_two_sites(self):
-        H = ConstantTIHamiltonian(size=2, interaction=np.kron(self.Sz, self.Sx))
-        Hmpo = H.to_mpo()
-        state = CanonicalMPS(self.random_uniform_mps(2, 2, D=2), center=0)
-
-        Q = QuadraticForm(Hmpo, state, start=0)
-        Hop = Q.two_site_Hamiltonian(0)
-        AB = _contract_last_and_first(state[0], state[1])
-        HopAB = Hop @ AB.reshape(-1)
-
-        self.assertEqual(HopAB.shape, (AB.size,))
-
-        expected = np.vdot(AB, HopAB)
-        exact_expected = Hmpo.expectation(state)
-        self.assertAlmostEqual(expected, exact_expected)  # type: ignore
-
-        HAB = H.to_matrix() @ AB.reshape(-1)
-        self.assertSimilar(HAB, HopAB)
-
-    def test_quadratic_form_three_sites_start_zero(self):
-        H = ConstantTIHamiltonian(size=3, interaction=np.kron(self.Sz, self.Sx))
-        Hmpo = H.to_mpo()
-        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
-
-        Q = QuadraticForm(Hmpo, state, start=0)
-        Hop = Q.two_site_Hamiltonian(0)
-        AB = _contract_last_and_first(state[0], state[1])
-        HopAB = Hop @ AB.reshape(-1)
-
-        self.assertEqual(HopAB.shape, (AB.size,))
-
-        expected = np.vdot(AB, HopAB)
-        exact_expected = Hmpo.expectation(state)
-        self.assertAlmostEqual(expected, exact_expected)  # type: ignore
-
-    def test_quadratic_form_three_sites_start_one(self):
-        H = ConstantTIHamiltonian(size=3, interaction=np.kron(self.Sz, self.Sx))
-        Hmpo = H.to_mpo()
-        state = CanonicalMPS(self.random_uniform_mps(2, 3, D=2), center=0)
-
-        Q = QuadraticForm(Hmpo, state, start=1)
-        Hop = Q.two_site_Hamiltonian(1)
-        AB = _contract_last_and_first(state[1], state[2])
-        HopAB = Hop @ AB.reshape(-1)
-
-        self.assertEqual(HopAB.shape, (AB.size,))
-
-        expected = np.vdot(AB, HopAB)
-        exact_expected = Hmpo.expectation(state)
-        self.assertAlmostEqual(expected, exact_expected)  # type: ignore
 
 
 class TestDMRG(SeeMPSTestCase):

--- a/tests/test_optimization/test_dmrg.py
+++ b/tests/test_optimization/test_dmrg.py
@@ -50,12 +50,12 @@ class TestDMRG(SeeMPSTestCase):
         self.assertAlmostEqual(Hmpo.expectation(result.state), -2)
 
     def test_dmrg_uses_guess_with_canonical_centers_other_than_zero(self):
-        """Check we can compute ground state of Sz * Sz on two sites"""
-        H = ConstantTIHamiltonian(size=2, interaction=-np.kron(self.Sz, self.Sz))
-        mps = CanonicalMPS(product_state([1.0, 1.0], 2), center=-1, normalize=True)
+        """Check we can compute ground state of Sz * Sz on three sites"""
+        H = ConstantTIHamiltonian(size=5, interaction=-np.kron(self.Sz, self.Sz))
+        mps = CanonicalMPS(product_state([1.0, 1.0], 5), center=3, normalize=True)
         Hmpo = H.to_mpo()
         result = dmrg(Hmpo, guess=mps, maxiter=100)
-        self.assertAlmostEqual(result.energy, -1)
+        self.assertAlmostEqual(result.energy, -4)
         v = result.state.to_vector()
-        self.assertAlmostEqual(v[0] ** 2 + v[3] ** 2, 1.0)
-        self.assertAlmostEqual(v[1] ** 2 + v[2] ** 2, 0.0)
+        self.assertAlmostEqual(v[0] ** 2 + v[-1] ** 2, 1.0)
+        self.assertAlmostEqual(sum(v[1:-1] ** 2), 0.0)


### PR DESCRIPTION
Currently, `QuadraticForm` is half-merged with DMRG, defined within `seemps/optimization/dmrg.py`. This difficults the clean implementation of other sweep-based algorithms.

This PR moves the class `QuadraticForm` to `seemps/operators/quadratic.py` as an entity on its own (analog to `AntilinearForm` in `seemps/state/antilinear.py`) and extends it to allow for the implementation of algorithms involving zero-, one-, and two-site operators, and one- and two-site gradients. `QuadraticForm` no longer deals with the specific local problem under consideration (eigenvalue search for DMRG, evolution for TDVP, etc), and these are defined in the files implementing these specific algorithms.

As a side-note, `QuadraticForm` now optionally takes a `ket` different from the `bra`. In that sense, the name is a bit of an abuse of notation.

The rest of the PR defines tests and updates existing algorithms and tests to import and use the new class.